### PR TITLE
W3c rebrand

### DIFF
--- a/common/css/vocabs.css
+++ b/common/css/vocabs.css
@@ -1,0 +1,50 @@
+/****************************************************/
+/*  property tables                                 */
+/****************************************************/
+
+/* ensure confomity of width for property tables */
+div.informaltable > table {
+	border-spacing: 0px;
+	border: none;
+	font-size: 1em;
+	width: 100%
+}
+
+div.informaltable > table td, div.informaltable > table th {
+	border: none;
+	background-color: rgb(236,246,255);
+	color: rgb(0,0,0);
+	padding: 0.3em;
+	vertical-align: top;
+}
+
+td.vocab-property > code {
+    color: rgb(0,50,116);
+    font-weight: bold;
+    font-size: 1.1em
+}
+
+div.informaltable > table td.vocab-property-header {
+    text-align: left;
+	vertical-align: top;
+    width: 8em;
+    border-right: 1px solid rgb(145,200,255);
+}
+
+div.informaltable > table td.vocab-property-header,
+div.informaltable > table td.vocab-property-border {
+    border-left: 5px solid rgb(145,200,255);
+}
+
+div.informaltable > table td.multi-para {
+    padding-top: 7px;
+}
+td.vocab-property-desc, td.entry, td.vocab-property {
+    padding: 3px 3px 3px 10px;
+}
+
+td.vocab-cardinality > p {
+	padding: 0em;
+	margin: 0em
+}
+

--- a/common/js/biblio.js
+++ b/common/js/biblio.js
@@ -1,0 +1,351 @@
+var biblio = {
+    "A11YTestSuite": {
+      "title": "EPUB Accessibility Tests",
+      "href": "https://github.com/daisy/epub-accessibility-tests"
+    },
+    "AccessibilityFAQ": {
+      "title": "EPUB Accessibility Frequently Asked Questions",
+      "href": "http://www.idpf.org/epub/guides/a11y-faq"
+    },
+    "AccessibilityVocab": {
+      "title": "EPUB Accessibility Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/package/a11y"
+    },
+    "AltStyleTags": {
+      "title": "Alternate Style Tags",
+      "href": "http://www.idpf.org/epub/altss-tags/",
+      "authors": [
+        "Elika J. Etemad"
+      ]
+    },
+    "AttributeExtensions": {
+      "title": "EPUB Custom Attribute Extensions for Content Documents",
+      "href": "http://www.idpf.org/epub/extensions/attributes"
+    },
+    "AuthorityRegistry": {
+      "title": "EPUB Subject Authorities Registry",
+      "href": "https://www.idpf.org/epub/registries/authorities/"
+    },
+    "CollectionPackageDoc": {
+      "title": "Using collection Elements as Embedded Package Documents",
+      "href": "http://www.idpf.org/epub/guides/collection-as-package"
+    },
+    "ContentDocs": {
+      "title": "EPUB Content Documents 3",
+      "href": "http://www.idpf.org/epub3/latest/contentdocs"
+    },
+    "ContentDocs32": {
+      "title": "EPUB Content Documents 3.2",
+      "href": "epub-contentdocs.html"
+    },
+    "ContentDocs31": {
+      "title": "EPUB Content Documents 3.1",
+      "href": "http://www.idpf.org/epub/31/spec/epub-contentdocs.html"
+    },
+    "ContentDocs301": {
+      "title": "EPUB Content Documents 3.0.1",
+      "href": "http://www.idpf.org/epub/301/spec/epub-contentdocs.html"
+    },
+    "ContentDocs30": {
+      "title": "EPUB Content Documents 3.0",
+      "href": "http://www.idpf.org/epub/30/spec/epub30-contentdocs.html"
+    },
+    "ContentDocsPrefixes": {
+      "title": "EPUB Content Documents Reserved Prefixes",
+      "href": "http://www.idpf.org/epub/vocab/structure/pfx"
+    },
+    "CoreMediaTypes": {
+      "title": "EPUB 3 Core Media Types",
+      "href": "https://www.idpf.org/epub/cmt/v3/"
+    },
+    "CSSSnapshot": {
+      "title": "CSS Snapshot",
+      "href": "https://www.w3.org/TR/CSS/"
+    },
+    "CSS-Text-3-20160119": {
+      "title": "CSS Text Level 3 (20160119)",
+      "href": "https://drafts.csswg.org/date/2016-01-19T17:23:23/css-text/",
+      "authors": [
+        "Elika J. Etemad"
+      ],
+      "etAl": true
+    },
+    "DAISYAudio": {
+      "title": "Navigable audio-only EPUB 3 Guidelines",
+      "href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
+    },
+    "Dictionaries": {
+      "title": "EPUB Dictionaries and Glossaries",
+      "href": "http://www.idpf.org/epub/dict"
+    },
+    "DistributableObjects": {
+      "title": "EPUB Distributable Objects 1.0",
+      "href": "http://www.idpf.org/epub/do"
+    },
+    "EPUB-CFI": {
+      "title": "EPUB Canonical Fragment Identifier (epubcfi) Specification",
+      "href": "http://www.idpf.org/epub/linking/cfi/epub-cfi.html"
+    },
+    "EPUB32": {
+    	"title": "EPUB 3.2",
+    	"href": "epub-spec.html"
+    },
+    "EPUB31": {
+      "title": "EPUB 3.1",
+      "href": "http://www.idpf.org/epub/31/spec/epub-spec.html"
+    },
+    "EPUB3": {
+      "title": "EPUB 3",
+      "href": "http://www.idpf.org/epub/latest"
+    },
+    "EPUB32Changes": {
+      "title": "EPUB 3.2 Changes",
+      "href": "epub-changes.html"
+    },
+    "EPUB32Overview": {
+      "title": "EPUB 3.2 Overview",
+      "href": "epub-overview.html"
+    },
+    "EPUBAccessibility": {
+      "title": "EPUB Accessibility",
+      "href": "http://www.idpf.org/epub/latest/accessibility"
+    },
+    "EPUBAccessibilityTechniques": {
+      "title": "EPUB Accessibility Techniques",
+      "href": "http://www.idpf.org/epub/latest/accessibility/techniques"
+    },
+    "H264": {
+      "title": "H.264 : Advanced video coding for generic audiovisual services",
+      "href": "https://www.itu.int/rec/T-REC-H.264-201602-P/en",
+      "date": "2016-02-13"
+    },
+    "HTML": {
+        "title": "HTML",
+        "href": "https://www.w3.org/TR/html/",
+        "status": "W3C Recommendation",
+        "publisher": "W3C"
+    },
+    "IDRegistry": {
+      "title": "EPUB Identifiers Registry",
+      "href": "https://www.idpf.org/epub/registries/identifiers/"
+    },
+    "Indexes": {
+      "title": "EPUB Indexes",
+      "href": "http://www.idpf.org/epub/idx"
+    },
+    "IPA": {
+      "title": "IPA Chart",
+      "href": "https://www.internationalphoneticassociation.org/content/full-ipa-chart",
+      "publisher": "International Phonetic Association",
+      "date": "2005"
+    },
+    "ISO24751-3": {
+      "title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
+      "href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
+      "date": "2008-10-01"
+    },
+    "ISOSchematron": {
+      "title": "ISO/IEC 19757-3: Rule-based validation — Schematron",
+      "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c040833_ISO_IEC_19757-3_2006(E).zip",
+      "date": "2006-06-01"
+    },
+    "LinkVocab": {
+      "title": "EPUB Metadata Link Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/package/link/"
+    },
+    "ManifestRole": {
+      "title": "EPUB Manifest Role",
+      "href": "http://www.idpf.org/epub/vocab/package/roles/manifest"
+    },
+    "ManifestVocab": {
+      "title": "EPUB Manifest Properties Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/package/item"
+    },
+    "MARCRelators": {
+      "title": "MARC Code List for Relators",
+      "href": "http://www.loc.gov/marc/relators/"
+    },
+    "MediaOverlays": {
+      "title": "EPUB Media Overlays 3.1",
+      "href": "http://www.idpf.org/epub3/latest/mediaoverlays"
+    },
+    "MediaOverlays32": {
+      "title": "EPUB Media Overlays 3.2",
+      "href": "epub-mediaoverlays.html"
+    },
+    "MediaOverlays31": {
+      "title": "EPUB Media Overlays 3.1",
+      "href": "http://www.idpf.org/epub/31/spec/epub-mediaoverlays.html"
+    },
+    "MediaOverlays301": {
+      "title": "EPUB Media Overlays 3.0.1",
+      "href": "http://www.idpf.org/epub/301/spec/epub-mediaoverlays.html"
+    },
+    "MediaOverlays30": {
+      "title": "EPUB Media Overlays 3.0",
+      "href": "http://www.idpf.org/epub/30/spec/epub30-mediaoverlays.html"
+    },
+    "MetaVocab": {
+      "title": "EPUB Meta Properties Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/package/meta"
+    },
+    "MultipleRenditions": {
+      "title": "EPUB Multiple-Rendition Publications 1.0",
+      "href": "http://www.idpf.org/epub/renditions/multiple/epub-multiple-renditions-20150826.html",
+      "date": "26 August 2015"
+    },
+    "NVDL": {
+      "title": "ISO/IEC 19757-4: NVDL (Namespace-based Validation Dispatching Language)",
+      "href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c038615_ISO_IEC_19757-4_2006(E).zip",
+      "date": "2006-06-01"
+    },
+    "OCF32": {
+      "title": "Open Container Format (OCF) 3.2",
+      "href": "epub-ocf.html"
+    },
+    "OCF31": {
+      "title": "Open Container Format (OCF) 3.1",
+      "href": "http://www.idpf.org/epub/31/spec/epub-ocf.html"
+    },
+    "OCF301": {
+      "title": "EPUB Open Container Format (OCF) 3.0.1",
+      "href": "http://www.idpf.org/epub/301/spec/epub-ocf.html"
+    },
+    "OCF30": {
+      "title": "EPUB Open Container Format (OCF) 3.0",
+      "href": "http://www.idpf.org/epub/30/spec/epub30-ocf.html"
+    },
+    "OCF2": {
+      "title": "EPUB Open Container Format (OCF) 2.0.1",
+      "href": "http://www.idpf.org/epub/20/spec/OCF_2.0.1_draft.doc"
+    },
+    "ODF": {
+      "title": "Open Document Format for Office Applications (OpenDocument) v1.0",
+      "href": "https://www.oasis-open.org/committees/download.php/12572/OpenDocument-v1.0-os.pdf",
+      "date": "1 May 2005"
+    },
+    "ONIX": {
+      "title": "ONIX for Books",
+      "href": "http://www.editeur.org/"
+    },
+    "OPF2": {
+      "title": "Open Packaging Format 2.0.1",
+      "href": "http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
+    },
+    "OPS2": {
+      "title": "Open Publication Structure 2.0.1",
+      "href": "http://idpf.org/epub/20/spec/OPS_2.0.1_draft.htm"
+    },
+    "OverlaysVocab": {
+      "title": "EPUB 3.1 Media Overlays Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/overlays/#"
+    },
+    "PackageDocPrefixes": {
+      "title": "EPUB Package Document Reserved Prefixes",
+      "href": "http://www.idpf.org/epub/vocab/package/pfx"
+    },
+    "Packages": {
+      "title": "EPUB Packages 3",
+      "href": "http://www.idpf.org/epub3/latest/packages"
+    },
+    "Packages32": {
+      "title": "EPUB Packages 3.2",
+      "href": "epub-packages.html"
+    },
+    "Packages31": {
+      "title": "EPUB Packages 3.1",
+      "href": "http://www.idpf.org/epub/31/spec/epub-packages.html"
+    },
+    "Previews": {
+      "title": "EPUB Previews",
+      "href": "http://www.idpf.org/epub/previews"
+    },
+    "Publications301": {
+      "title": "EPUB Publications 3.0.1",
+      "href": "http://www.idpf.org/epub/301/spec/epub-publications.html"
+    },
+    "Publications30": {
+    	"title": "EPUB Publications 3.0",
+    	"href": "http://www.idpf.org/epub/30/spec/epub30-publications.html"
+    },
+    "RegionNav": {
+      "title": "EPUB Region-Based Navigation",
+      "href": "http://www.idpf.org/epub/renditions/region-nav"
+    },
+    "RenditionVocab": {
+      "title": "EPUB Package Rendering Vocabulary",
+      "href": "http://www.idpf.org/vocab/rendition"
+    },
+    "RFC": {
+      "title": "Request for Comments",
+      "href": "https://www.ietf.org/rfc.html"
+    },
+    "RoleExtensions": {
+      "title": "EPUB Collection Element Role Extensions",
+      "href": "http://www.idpf.org/epub/extensions/roles"
+    },
+    "RoleRegistry": {
+      "title": "EPUB Collection Roles Registry",
+      "href": "http://www.idpf.org/epub/registries/roles"
+    },
+    "schema.org": {
+      "title": "schema.org",
+      "href": "https://schema.org"
+    },
+    "SchemaGuide": {
+      "title": "Schema.org Metadata Integration Guide for EPUB 3",
+      "href": "http://www.idpf.org/epub/guides/schema-org-integration"
+    },
+    "ScriptableComponents": {
+      "title": "EPUB Scriptable Components 1.0",
+      "href": "http://www.idpf.org/epub/sc/api"
+    },
+    "ScriptableComponents-Packaging": {
+      "title": "EPUB Scriptable Components Packaging and Integration 1.0",
+      "href": "http://www.idpf.org/epub/sc/pkg"
+    },
+    "SHA-1": {
+      "title": "Federal Information Processing Standards Publication 180-3: Secure Hash Standard (SHS)",
+      "href": "http://csrc.nist.gov/publications/fips/fips180-3/fips180-3_final.pdf",
+      "date": "October 2008"
+    },
+    "SpineVocab": {
+      "title": "EPUB Spine Properties Vocabulary",
+      "href": "http://www.idpf.org/epub/vocab/package/itemref"
+    },
+    "SWF": {
+      "title": "SWF File Format Specification</link> Version 19",
+      "href": "http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf",
+      "date": "2012"
+    },
+    "TR15": {
+      "title": "Unicode Normalization Forms",
+      "href": "http://www.unicode.org/reports/tr15/"
+    },
+    "TypesRegistry": {
+      "title": "EPUB Publication Types Registry",
+      "href": "http://www.idpf.org/epub/vocab/package/types"
+    },
+    "US-ASCII": {
+      "title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
+    },
+    "W3CProcess": {
+      "title": "World Wide Web Consortium Process Document",
+      "href": "https://www.w3.org/2015/Process-20150901/",
+      "authors": [
+        "Charles McCathie-Nevile"
+      ],
+      "date": "1 September 2015"
+    },
+    "XPTRSH": {
+      "title": "XPointer Shorthand Notation",
+      "href": "https://www.w3.org/TR/2003/REC-xptr-framework-20030325/",
+      "date": "25 March 2003"
+    },
+    "ZIPAPPNOTE633": {
+      "title": "ZIP File Format Specification",
+      "href": "http://www.pkware.com/documents/APPNOTE/APPNOTE-6.3.3.TXT",
+      "date": "September 1, 2012",
+      "publisher": "PKWARE, Inc."
+    }
+}

--- a/common/js/orcid.js
+++ b/common/js/orcid.js
@@ -1,0 +1,55 @@
+/**
+* Add an orcid image linked to the authors' and editors' ORCID ID-s (when applicable)
+*
+* The trigger is an additional "orcid" key in the person's object in the respec config. The "w3cid" key is also necessary (to be used anyway...)
+*/
+function show_orcid(config) {
+	let orcidmaps = {
+	};
+
+	//--------------------------------------------------------------------------------
+	// 1st step: find the authors/editors who have set their ORCID number as part of the persons' structure
+	// This can be extracted from the configuration set by the user (and extended by respec)
+	let personKeys = ["editors", "authors"];
+	personKeys.forEach( key => {
+		if( config[key] ) {
+			config[key].forEach( (editor) => {
+				if(editor.orcid && editor.w3cid) {
+					orcidmaps[editor.w3cid] = editor.orcid
+				}
+			});					
+		}
+	});
+
+	//---------------------------------------------------------------------------------
+	// 2nd step: find the persons in the header, see if their id is listed in orcidmap and, if yes
+	// add the additional image reference.
+	//
+	// 
+	// Persons are in a dd element with the class set to p-author (and some others)
+	document.querySelectorAll("dd.p-author").forEach( (element) => {
+		// Look at the data-editor-id value to see if it is relevant.
+		if( element.dataset.editorId ) {
+			// Get the possible ordicId from the orcid mapping
+			orcidId = orcidmaps[element.dataset.editorId]
+			if(orcidId) {
+				// Bingo; add a span with the image linked to the orcid web site
+				let span = document.createElement('span');
+				let a    = document.createElement('a');
+				let img  = document.createElement('img');
+
+				img.setAttribute('src','https://orcid.org/sites/default/files/images/orcid_16x16.gif');
+				img.setAttribute('alt','orcid logo');
+
+				a.setAttribute('href', `https://orcid.org/${orcidId}`);
+				a.appendChild(img);
+
+				span.setAttribute('class', 'orcid');
+				span.appendChild(a);
+
+				element.innerHTML += " "; 
+				element.appendChild(span);
+			}
+		}
+	});
+}

--- a/vocab/overlays/overlays.html
+++ b/vocab/overlays/overlays.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Media Overlays Metadata Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../common/css/vocabs.css" />
+		<script src="../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/overlays/overlays.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Marisa Demeglio",
+						company: "DAISY Consortium",
+						companyURL: "http://daisy.org",
+					},
+					{
+						name: "Daniel Weck",
+						company: "DAISY Consortium",
+						companyURL: "http://daisy.org",
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This vocabulary defines a set of properties for describing Media Overlays [[MediaOverlays]] in the <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-metadata-elem">Package Document metadata</a>
+				[[Packages]].</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-purpose-scope" class="informative">
+				<h3>Purpose and Scope</h3>
+
+				<p>This vocabulary is a companion to the EPUB Media Overlays 3 [[MediaOverlays]] specification and is
+					intended to be read in conjunction with that document.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>The base IRI for referencing this vocabulary is
+						<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
+
+				<p>The prefix "<code>media:</code>" is <a
+						href="http://www.idpf.org/epub3/latest/packages#sec-metadata-reserved-prefixes">reserved for
+						use</a> [[!Packages]] with properties in this vocabulary and does not have to be declared in the
+					Package Document.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
+					System"). A complete list of these <a href="http://www.idpf.org/epub3/latest#sec-terminology">terms
+						and definitions</a> is provided in [[!EPUB3]].</p>
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-meta-property-values">
+			<h2>Media Overlays Properties</h2>
+
+			<section id="sec-active-class">
+				<h3>active-class</h3>
+
+				<div class="informaltable" id="active-class">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>active-class</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Author-defined CSS class name to apply to the
+									currently-playing EPUB Content Document element.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">Zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta
+										property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-duration">
+				<h3>duration</h3>
+
+				<div class="informaltable" id="duration">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>duration</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The duration of the entire presentation or of a specific
+									Media Overlay. The specified durations account for the audio clips known at
+									authoring time, and so exclude live streaming from external resources and speech
+									synthesis.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">A clock value. <p>MUST be a [[!SMIL]] <a
+											href="http://www.w3.org/TR/SMIL/smil-timing.html#q22">clock value</a>.</p>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">Exactly one for a given <span class="phrase"><a class="glossterm"
+											href="http://www.idpf.org/epub3/latest#gloss-rendition">Rendition</a></span>
+									and for each Media Overlay.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta
+										property="media:duration"&gt;1:36:20&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-narrator">
+				<h3>narrator</h3>
+
+				<div class="informaltable" id="narrator">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>narrator</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Name of the narrator.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta property="media:narrator"&gt;Joe
+										Speaker&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-playback-active-class">
+				<h3>playback-active-class</h3>
+
+				<div class="informaltable" id="playback-active-class">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>playback-active-class</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Author-defined CSS class name to apply to the EPUB
+									Content Document's document element when playback is active.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">Zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta
+										property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</section>
+	</body>
+</html>

--- a/vocab/package/a11y/a11y.html
+++ b/vocab/package/a11y/a11y.html
@@ -1,0 +1,218 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Accessibility Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../../common/css/vocabs.css" />
+		<script src="../../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/package/a11y/a11y.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://www.daisy.org",
+						w3cid: 51655
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This vocabulary defines properties for describing the accessibility of EPUB Publications in the
+				Package Document metadata.</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-about" class="informative">
+				<h3>About this Vocabulary</h3>
+
+				<p>This vocabulary is a companion to the <a href="http://www.idpf.org/epub/a11y/epub-a11y.html">EPUB
+						Accessibility</a> specification and is intended to be read in conjunction with that
+					document.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>The base IRI for referencing this vocabulary is <code class="uri"
+						>http://www.idpf.org/epub/vocab/package/a11y/#</code>.</p>
+
+				<p>The prefix "<code>a11y:</code>" is <a href="http://www.idpf.org/epub/vocab/package/pfx"
+						>reserved for use</a> with properties in this vocabulary and does not have to be declared in the
+					Package Document.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB are capitalized in this document (e.g., "Author", "Reading
+					System"). See the <a href="http://www.idpf.org/epub/a11y/epub-a11y.html">EPUB Accessibility</a>
+					specification for their meanings.</p>
+
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-meta-property-values">
+			<h2>Conformance Properties</h2>
+
+			<section id="sec-certifiedBy">
+				<h3>certifiedBy</h3>
+
+				<div class="informaltable" id="certifiedBy">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>certifiedBy</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Identifies a party responsible for the testing and
+									certification of the accessibility of an EPUB Publication.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">One or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta property="a11y:certifiedBy"&gt;Accessibility
+										Testers Group&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-certifierCredential">
+				<h3>certifierCredential</h3>
+
+				<div class="informaltable" id="certifierCredential">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>certifierCredential</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Identifies a credential or badge that establishes the
+									authority of the party identified in the <a href="#sec-certifiedBy"><code
+											class="markup">certifiedBy</code> property</a> to certify content
+									accessible.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;meta property="a11y:certifierCredential"&gt;DAISY
+										OK&lt;/meta&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-certifierReport">
+				<h3>certifierReport</h3>
+
+				<div class="informaltable" id="certifierReport">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>certifierReport</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Provides a link to an accessibility report created by
+									the party identified in the <a href="#sec-certifiedBy"><code class="markup"
+											>certifiedBy</code> property</a>.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Allowed value(s):</td>
+								<td class="entry">
+									<code class="datatype">xsd:anyURI</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="entry">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code class="prop-example">&lt;link rel="a11y:certifierReport"
+										href="http://example.com/a11y/reports/9780000000001"/&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</section>
+	</body>
+</html>

--- a/vocab/package/item/item.html
+++ b/vocab/package/item/item.html
@@ -1,0 +1,398 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Manifest Properties Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../../common/css/vocabs.css" />
+		<script src="../../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/package/item/item.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://www.daisy.org",
+						w3cid: 51655
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract"> </section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-about" class="informative">
+				<h3>About this Vocabulary</h3>
+
+				<p> This vocabulary defines a set of properties for describing various features of the <a
+						href="http://www.idpf.org/epub3/latest/packages#sec-package-doc">Package Document</a>
+					<a class="biblioref" href="#refPackages3" title="EPUB Packages 3">[<abbr>Packages3</abbr>]</a>.</p>
+
+				<p>The properties in this vocabulary are usable in the various Package Document attributes that accept
+					the <a href="http://www.idpf.org/epub3/latest/packages#sec-property-datatype">property datatype</a>
+					[[Packages]], and are grouped by the element and attribute that they can be used in.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>Properties without a prefix are referenceable using the base IRI
+						<code>http://idpf.org/epub/vocab/package/#</code>.</p>
+			</section>
+
+			<section xml:lang="en" id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
+					System"). A complete list of these <a href="http://www.idpf.org/epub3/latest#sec-terminology">terms
+						and definitions</a> is provided in [[!EPUB3]].</p>
+
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-item-property-values">
+			<h2>Manifest <code>item</code> Properties</h2>
+
+			<p>The following tables define properties for use in the <code>manifest</code>
+				<a href="http://www.idpf.org/epub3/latest/packages#sec-item-elem">item element</a>
+				<a href="http://www.idpf.org/epub3/latest/packages#attrdef-item-properties">properties attribute</a>
+				[[!Packages]].</p>
+
+			<p>The <strong>Applies to</strong> field indicates which Publication Resource type(s) the given property MAY
+				be specified on, the <strong>Cardinality</strong> field indicates the number of times the property MUST
+				appear within the Package Document scope, and the <strong>Usage</strong> field indicates usage
+				conditions.</p>
+
+			<section id="sec-cover-image">
+				<h3>cover-image</h3>
+
+				<div class="informaltable" id="cover-image">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>cover-image</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>cover-image</code> property identifies the
+									described Publication Resource as the cover image for the Publication.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry">All <a href="http://www.idpf.org/epub3/latest#tbl-core-media-types"
+										>raster and vector image types</a> [[!EPUB3]]</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or one</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">Optional.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-mathml">
+				<h3>mathml</h3>
+
+				<div class="informaltable" id="mathml">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>mathml</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>mathml</code> property indicates that the
+									described Publication Resource contains one or more instances of MathML markup.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry"><a href="http://www.idpf.org/epub3/latest#gloss-content-document-epub"
+										>EPUB Content Documents</a></td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">MUST be set if and only if the criterion specified in the description
+									is met.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-nav">
+				<h3>nav</h3>
+
+				<div class="informaltable" id="nav">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>nav</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>nav</code> property indicates that the
+									described Publication Resource constitutes the <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-nav">EPUB
+										Navigation Document</a> of the given <a class="glossterm"
+										href="http://www.idpf.org/epub3/latest#gloss-rendition">Rendition</a>
+									[[!Packages]].</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry">The <a
+										href="http://www.idpf.org/epub3/latest/packages#gloss-content-document-epub-nav"
+										>EPUB Navigation Document</a>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Exactly one</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">Required.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-remote-resources">
+				<h3>remote-resources</h3>
+
+				<div class="informaltable" id="remote-resources">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>remote-resources</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header multi-para">Description:</td>
+								<td class="vocab-property-desc">
+									<p>The <code>remote-resources</code> property indicates that the described
+										Publication Resource contains one or more internal references to other
+										Publication Resources that are located outside of the <a
+											href="http://www.idpf.org/epub3/latest#gloss-container">EPUB
+										Container</a>.</p>
+									<p>Refer to <a href="http://www.idpf.org/epub3/latest#sec-resource-locations"
+											>Publication Resource Locations</a> [[!EPUB3]] for more information.</p>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry">All Publication Resources with the capability of internal referencing
+									(e.g., <a href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-xhtml"
+										>XHTML Content Documents</a>, <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-svg">SVG
+										Content Documents</a>, CSS Style Sheets and <a
+										href="http://www.idpf.org/epub3/latest#gloss-media-overlay-document">Media
+										Overlay Documents</a>).</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">MUST be set if and only if the criterion specified in the description
+									is met.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-scripted">
+				<h3>scripted</h3>
+
+				<div class="informaltable" id="scripted">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>scripted</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>scripted</code> property indicates that the
+									described Publication Resource is a <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-scripted"
+										>Scripted Content Document</a> (i.e., contains scripted content and/or HTML form
+									elements).</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry"><a href="http://www.idpf.org/epub3/latest#gloss-content-document-epub"
+										>EPUB Content Documents</a></td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">MUST be set if and only if the criterion specified in the description
+									is met.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-svg">
+				<h3>svg</h3>
+
+				<div class="informaltable" id="svg">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>svg</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">
+									<p>The <code>svg</code> property indicates that the described Publication Resource
+										embeds one or more instances of SVG markup.</p>
+									<p>This property MUST be set when SVG markup is included directly in the resource
+										and MAY be set when the SVG is referenced from the resource (e.g., from an
+										[[HTML]] <code>img</code>, <code>object</code> or <code>iframe</code>
+										element).</p>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Applies to:</td>
+								<td class="entry"><a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-xhtml">XHTML
+										Content Documents</a>; the value is implied for <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-svg">SVG
+										Content Documents</a>.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Usage:</td>
+								<td class="entry">MUST be set if and only if the criterion specified in the description
+									is met.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="manifest-item-properties-recursive">
+				<h3>Usage</h3>
+
+				<p>The <code>mathml</code>, <code>remote-resources</code> and <code>scripted</code> properties MUST be
+					specified whenever the resource referenced by an <code>item</code> matches their respective
+					definitions. These properties do not apply recursively to content included into a resource (e.g.,
+					via the HTML <code>iframe</code> element). For example, if a non-scripted XHTML Content Document
+					embeds a scripted Content Document, only the embedded document's manifest <code>item</code>
+					<code>properties</code> attribute will have the <code>scripted</code> value. </p>
+			</section>
+
+			<section id="examples-item-properties">
+				<h3>Examples</h3>
+
+				<figure class="example" id="example-item-properties-nav">
+					<figcaption>The following example shows a <code>manifest</code>
+						<a href="http://www.idpf.org/epub3/latest/packages#sec-item-elem"><code>item</code> element</a>
+						[[Packages]] that represents the <a
+							href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-nav">EPUB Navigation
+							Document</a>.</figcaption>
+					<pre class="synopsis">&lt;item properties="nav" id="c1" href="c1.xhtml" media-type="application/xhtml+xml" /&gt;&#xD;
+</pre>
+				</figure>
+
+				<figure class="example" id="example-item-properties-cover-image">
+					<figcaption>The following example shows a <code>manifest</code>
+						<code>item</code> element that represents the cover image.</figcaption>
+					<pre class="synopsis">&lt;item properties="cover-image" id="ci" href="cover.svg" media-type="image/svg+xml" /&gt;&#xD;
+</pre>
+				</figure>
+
+				<figure class="example" id="example-item-properties-scripted-mathml">
+					<figcaption>The following example shows a <code>manifest</code>
+						<code>item</code> element representing a <a
+							href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-scripted">Scripted
+							Content Document</a> that also contains embedded MathML.</figcaption>
+					<pre class="synopsis">&lt;item properties="scripted mathml" id="c2" href="c2.xhtml" media-type="application/xhtml+xml" /&gt;&#xD;
+</pre>
+				</figure>
+			</section>
+		</section>
+	</body>
+</html>

--- a/vocab/package/itemref/itemref.html
+++ b/vocab/package/itemref/itemref.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Spine Properties Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../../common/css/vocabs.css" />
+		<script src="../../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/package/itemref/itemref.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://www.daisy.org",
+						w3cid: 51655
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This vocabulary defines a set of properties for describing various features of the <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-package-doc">Package Document</a>
+				[[Packages]].</p>
+		</section>
+		<section id="sotd">
+			<h2>Status of this Document</h2>
+
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-about" class="informative">
+				<h3>About this Vocabulary</h3>
+
+				<p>The properties in this vocabulary are usable in the various Package Document attributes that accept
+					the <a href="http://www.idpf.org/epub3/latest/packages#sec-property-datatype">property datatype</a>
+					[[Packages]], and are grouped by the element and attribute that they can be used in.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>Properties are referenceable using the base IRI
+					<code>http://idpf.org/epub/vocab/package/#</code>.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
+					System"). A complete list of these <a href="http://www.idpf.org/epub3/latest#sec-terminology">terms
+						and definitions</a> is provided in [[!EPUB3]].</p>
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-itemref-property-values">
+			<h2>Spine <code>itemref</code> Properties</h2>
+
+			<p>The following tables define properties for use in the <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-itemref-elem"><code>itemref</code> element</a>
+				<a href="http://www.idpf.org/epub3/latest/packages#attrdef-itemref-properties"><code>properties</code>
+					attribute</a> [[!Packages]].</p>
+
+			<section id="sec-page-spread-left">
+				<h3>page-spread-left</h3>
+
+				<div class="informaltable" id="page-spread-left">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>page-spread-left</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>page-spread-left</code> property indicates
+									that the first page of the associated <code>item</code> element's <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub">EPUB Content
+										Document</a> represents the left-hand side of a two-page spread.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="sec-page-spread-right">
+				<h3>page-spread-right</h3>
+
+				<div class="informaltable" id="page-spread-right">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>page-spread-right</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>page-spread-right</code> property indicates
+									that the first page of the associated <code>item</code> element's <a
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub">EPUB Content
+										Document</a> represents the right-hand side of a two-page spread.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+			<section id="examples-itemref-properties">
+				<h3>Examples</h3>
+
+				<figure class="example" id="example-itemref-multicol">
+					<figcaption>The following example shows how a two-page spread of a map might be indicated in the
+							<code>spine</code>.</figcaption>
+					<pre class="synopsis">&lt;spine&gt;&#xD;
+	&lt;itemref idref="title"/&gt;&#xD;
+	&lt;itemref idref="ps-1-l" properties="page-spread-left"/&gt;&#xD;
+	&lt;itemref idref="ps-1-r" properties="page-spread-right"/&gt;&#xD;
+	&lt;itemref idref="toc"/&gt;&#xD;
+	…&#xD;
+&lt;/spine&gt;</pre>
+				</figure>
+			</section>
+		</section>
+	</body>
+</html>

--- a/vocab/package/link/link.html
+++ b/vocab/package/link/link.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Metadata Link Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../../common/css/vocabs.css" />
+		<script src="../../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/package/link/link.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://www.daisy.org",
+						w3cid: 51655
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This document defines relationships and properties for use with the EPUB® Package Document <a
+					href="http://www.idpf.org/epub3/latest/packages/#sec-link-elem"><code>link</code> element</a>
+				[[Packages]].</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="sec-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document. A complete list of these <a
+						href="http://www.idpf.org/epub3/latest/#sec-terminology">terms and definitions</a> is provided
+					in [[!EPUB3]].</p>
+
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-link-rel">
+			<h2>Link Relationships</h2>
+
+			<p>The following values can be used in the <code>link</code> element <a
+					href="http://www.idpf.org/epub3/latest/packages#attrdef-link-rel"><code>rel</code> attribute</a> to
+				establish the relationship of the resource referenced in the <a
+					href="http://www.idpf.org/epub3/latest/packages#attrdef-link-href"><code>href</code> attribute</a>
+				[[!Packages]].</p>
+
+			<section id="sec-acquire">
+				<h3>acquire</h3>
+
+				<div class="informaltable" id="acquire">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>acquire</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>acquire</code> keyword is used with <a
+										href="http://www.idpf.org/epub/previews">EPUB Previews</a> to identify where the
+									full version of the <a
+										href="http://www.idpf.org/epub3/latest/#gloss-epub-publication">EPUB
+										Publication</a> can be acquired.</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry"><code>&lt;link rel="acquire"
+										href="http://example.org/book/9781448103706"
+									media-type="text/html"/&gt;</code></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-alternate">
+				<h3>alternate</h3>
+
+				<div class="informaltable" id="alternate">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>alternate</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">
+									<p>The <code>alternate</code> keyword is a subset of the <a
+											href="https://www.w3.org/TR/html/links.html#link-type-alternate">HTML
+												<code>alternate</code> keyword</a> for links. It differs as follows:</p>
+									<ul>
+										<li>It cannot be paired with other keywords.</li>
+										<li>If an alternate link is included in the Package Document metadata, it
+											identifies an alternate representation of the Package Document in the format
+											specified in the <code>media-type</code> attribute.</li>
+										<li>If an alternate link is included in a <a
+												href="http://www.idpf.org/epub3/latest/packages/#sec-collection-elem"
+													><code>collection</code> element's</a> metadata [[!Packages]], it
+											identifies an alternate representation of the <code>collection</code> in the
+											format specified in the <code>media-type</code> attribute.</li>
+										<li>Reading Systems do not have to generate hyperlinks for alternate links.</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code>&lt;link rel="alternate" href="package.json"
+										media-type="application/json-ld"/&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-marc21xml-record">
+				<h3>marc21xml-record</h3>
+
+				<div class="informaltable" id="marc21xml-record">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>marc21xml-record</code>
+									<span class="status deprecated">[DEPRECATED]</span>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Use of the <code>marc21xml-record</code> keyword is
+									deprecated. It is replaced by the <a href="#record"><code>record</code></a> keyword
+									with the <a
+										href="http://www.idpf.org/epub3/latest/packages/#attrdef-link-media-type"
+											><code>media-type</code> attribute</a> [[!Packages]] value
+										"<code>application/marcxml+xml</code>".</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-mods-record">
+				<h3>mods-record</h3>
+
+				<div class="informaltable" id="mods-record">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>mods-record</code>
+									<span class="status deprecated">[DEPRECATED]</span>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Use of the <code>mods-record</code> keyword is
+									deprecated. It is replaced by the <a href="#record"><code>record</code></a> keyword
+									with the <a
+										href="http://www.idpf.org/epub3/latest/packages/#attrdef-link-media-type"
+											><code>media-type</code> attribute</a> [[!Packages]] value
+										"<code>application/mods+xml</code>".</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-onix-record">
+				<h3>onix-record</h3>
+
+				<div class="informaltable" id="onix-record">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>onix-record</code>
+									<span class="status deprecated">[DEPRECATED]</span>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Use of the <code>onix-record</code> keyword is
+									deprecated. It is replaced by the <a href="#record"><code>record</code></a> keyword
+									with the <a
+										href="http://www.idpf.org/epub3/latest/packages/#attrdef-link-properties"
+										>properties attribute</a> [[!Packages]] value <a href="#onix"
+										><code>onix</code></a>.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-record">
+				<h3>record</h3>
+
+				<div class="informaltable" id="record">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>record</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">
+									<p>Indicates that the referenced resource is a metadata record.</p>
+									<p>The media type of the record is identified in the <a
+											href="http://www.idpf.org/epub3/latest/packages#attrdef-link-media-type"
+												><code>media-type</code> attribute</a> [[!Packages]] when this keyword
+										is specified.</p>
+									<p>For a list of commonly-linked metadata record types, refer to the <a
+											href="http://www.idpf.org/epub/guides/linked-records/">EPUB Linked Metadata
+											Guide</a></p>
+									<p>If the type of record cannot be identified from the media type, an <a
+											href="#sec-link-properties">identifier property</a> can be assigned in the
+											<a href="http://www.idpf.org/epub3/latest/packages#attrdef-link-properties"
+												><code>properties</code> attribute</a> [[!Packages]].</p>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Cardinality:</td>
+								<td class="vocab-cardinality">
+									<code class="option">Zero or more</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry"><code>&lt;link rel="record" href="book/52.atom"
+										media-type="application/atom+xml;type=entry;profile=opds-catalog"/&gt;</code></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-xml-signature">
+				<h3>xml-signature</h3>
+
+				<div class="informaltable" id="xml-signature">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>xml-signature</code>
+									<span class="status deprecated">[DEPRECATED]</span>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Use of the <code>xml-signature</code> keyword is
+									deprecated. It is not replaced by another linking method. Identification of XML
+									signatures will be addressed in a future version of EPUB.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-xmp-record">
+				<h3>xml-record</h3>
+
+				<div class="informaltable" id="xml-record">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>xml-record</code>
+									<span class="status deprecated">[DEPRECATED]</span>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">Use of the <code>xmp-record</code> keyword is
+									deprecated. It is replaced by the <a href="#record"><code>record</code></a> keyword
+									with the <a
+										href="http://www.idpf.org/epub3/latest/packages/#attrdef-link-properties"
+										>properties attribute</a> value <a href="#xmp"><code>xmp</code></a>.</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</section>
+		<section id="sec-link-properties">
+			<h2>Link Properties</h2>
+
+			<p>The following values can be used in the <code>link</code> element <a
+					href="http://www.idpf.org/epub3/latest/packages#attrdef-link-rel"><code>rel</code> attribute</a>
+				[[!Packages]] to establish the type of record a referenced resource represents. These values are
+				provided for record formats that cannot be uniquely identified by their media type.</p>
+
+			<section id="sec-onix">
+				<h3>onix</h3>
+
+				<div class="informaltable" id="onix">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>onix</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>onix</code> property indicates the referenced
+									resource is an ONIX record [[!ONIX]].</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry"><code>&lt;link rel="record" href="pub/meta/nor-wood-onix.xml"
+										media-type="application/xml" properties="onix"/&gt;</code></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<section id="sec-xmp">
+				<h3>xmp</h3>
+
+				<div class="informaltable" id="xmp">
+					<table>
+						<tbody>
+							<tr>
+								<td class="vocab-property-header">Name:</td>
+								<td class="vocab-property">
+									<code>xmp</code>
+								</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Description:</td>
+								<td class="vocab-property-desc">The <code>xmp</code> property indicates the referenced
+									resource is an XMP record [[!XMP]].</td>
+							</tr>
+							<tr>
+								<td class="vocab-property-header">Example:</td>
+								<td class="entry">
+									<code>&lt;link rel="record" href="pub/meta/nor-wood-xmp.xml
+										media-type="application/xml" properties="xmp"/&gt;</code>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+		</section>
+	</body>
+</html>

--- a/vocab/package/meta/meta.html
+++ b/vocab/package/meta/meta.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Meta Properties Vocabulary</title>
+		<link rel="stylesheet" type="text/css" href="../../../common/css/vocabs.css" />
+		<script src="../../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/package/meta/meta.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Matt Garrish",
+						company: "DAISY Consortium",
+						companyURL: "http://www.daisy.org",
+						w3cid: 51655
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This vocabulary defines a set of properties for describing various features of the <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-package-doc">Package Document</a>
+				[[Packages]].</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+			
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+			
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-about" class="informative">
+				<h3>About this Vocabulary</h3>
+
+				<p>The properties in this vocabulary are usable in the various Package Document attributes that accept
+					the <a href="http://www.idpf.org/epub3/latest/packages#sec-property-datatype">property datatype</a>
+					[[Packages]], and are grouped by the element and attribute that they can be used in.</p>
+
+				<p>This vocabulary is a companion to the [[Packages]] specification and is intended to be read in
+					conjunction with that document.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>Properties without a prefix are referenceable using the base IRI
+						<code>http://idpf.org/epub/vocab/package/#</code>.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
+					System"). A complete list of these <a href="http://www.idpf.org/epub3/latest#sec-terminology">terms
+						and definitions</a> is provided in [[!EPUB3]].</p>
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-meta-property-values">
+			<h2>Metadata <code>meta</code> Properties</h2>
+
+			<p>No properties are currently defined.</p>
+		</section>
+	</body>
+</html>

--- a/vocab/rendition/rendition.html
+++ b/vocab/rendition/rendition.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB Package Rendering Vocabulary</title>
+		<script src="../../common/js/biblio.js" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/rendition/rendition.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						name: "Dave Cramer",
+						company: "Hachette Livre",
+						companyURL: "https://www.hachettebookgroup.com",
+					},
+					{
+						name: "Garth Conboy",
+						company: "Google",
+						companyURL: "https://google.com",
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				},
+				localBiblio: biblio
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This vocabulary defines a set of properties for describing various features of the EPUB® <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-package-doc">Package Document</a>
+				[[Packages]].</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="elemdef-opf-meta-overview">
+			<h2>Overview</h2>
+
+			<section id="sec-about" class="informative">
+				<h3>About this Vocabulary</h3>
+
+				<p>The properties in this vocabulary are usable in the various Package Document attributes that accept a
+						<a href="http://www.idpf.org/epub3/latest/packages#sec-property-datatype">property datatype</a>
+					[[Packages]], and are grouped by the element and attribute that they are allowed in.</p>
+			</section>
+
+			<section id="sec-ref">
+				<h3>Referencing</h3>
+
+				<p>Properties are referenceable using the base IRI <code class="uri"
+						>http://www.idpf.org/vocab/rendition/#</code>.</p>
+
+				<p>The "<code>rendition:</code>" prefix is <a
+						href="http://www.idpf.org/epub3/latest/packages#sec-metadata-reserved-prefixes">reserved for
+						use</a> [[!Packages]] with these properties and does not have to be declared in the Package
+					Document.</p>
+			</section>
+
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
+					System"). A complete list of these <a href="http://www.idpf.org/epub3/latest#sec-terminology">terms
+						and definitions</a> is provided in [[!EPUB3]].</p>
+
+				<p>Only the first instance of a term in a section is linked to its definition.</p>
+			</section>
+			<section id="conformance"></section>
+		</section>
+		<section id="sec-meta-property-values">
+			<h2>Metadata <code>meta</code> Properties</h2>
+
+			<dl>
+				<dt id="flow"> flow </dt>
+				<dd>Specifies the Author preference for how Reading Systems should handle content overflow. </dd>
+
+				<dt id="layout"> layout </dt>
+				<dd>Specifies whether the given Rendition is reflowable or pre-paginated. </dd>
+
+				<dt id="orientation"> orientation </dt>
+				<dd>Specifies which orientation the Author intends the given Rendition to be rendered in. </dd>
+
+				<dt id="spread"> spread </dt>
+				<dd>Specifies the intended Reading System synthetic spread behavior for the given Rendition. </dd>
+
+				<dt id="viewport">viewport</dt>
+				<dd>The <code>viewport</code> property is <a href="http://www.idpf.org/epub3/latest#deprecated"
+						>deprecated</a> in [[!EPUB3]]. Refer to its definition in [[!Publications301]] for more
+					information.</dd>
+			</dl>
+		</section>
+		<section id="sec-itemref-property-values">
+			<h2>Spine <code>itemref</code> Properties</h2>
+
+			<p>The following tables define properties for use in the <a
+					href="http://www.idpf.org/epub3/latest/packages#sec-itemref-elem"><code>itemref</code> element</a>
+				<a href="http://www.idpf.org/epub3/latest/packages#attrdef-itemref-properties"><code>properties</code>
+					attribute</a> [[!Packages]].</p>
+
+			<dl>
+				<dt id="align-x-center"> align-x-center </dt>
+				<dd>Specifies that the given spine item should be centered horizontally in the viewport or spread. </dd>
+
+				<dt id="flow-auto"> flow-auto </dt>
+				<dd>Indicates no preference for overflow content handling by the Author. </dd>
+
+				<dt id="flow-paginated"> flow-paginated </dt>
+				<dd>Indicates the Author preference is to dynamically paginate content overflow. </dd>
+
+				<dt id="flow-scrolled-continuous"> flow-scrolled-continuous </dt>
+				<dd> Indicates the Author preference is to provide a scrolled view for overflow content, and that
+					consecutive spine items with this property are to be rendered as a continuous scroll. </dd>
+
+				<dt id="flow-scrolled-doc"> flow-scrolled-doc </dt>
+				<dd> Indicates the Author preference is to provide a scrolled view for overflow content, and each spine
+					item with this property is to be rendered as separate scrollable document. </dd>
+
+				<dt id="layout-pre-paginated"> layout-pre-paginated </dt>
+				<dd> Specifies that the given spine item is pre-paginated. </dd>
+
+				<dt id="layout-reflowable"> layout-reflowable </dt>
+				<dd> Specifies that the given spine item is reflowable. </dd>
+
+				<dt id="orientation-auto"> orientation-auto </dt>
+				<dd> Specifies that the Reading System can determine the orientation to rendered the spine item in. </dd>
+
+				<dt id="orientation-landscape"> orientation-landscape </dt>
+				<dd> Specifies that the given spine item is to be rendered in landscape orientation. </dd>
+
+				<dt id="orientation-portrait"> orientation-portrait </dt>
+				<dd> Specifies that the given spine item is to be rendered in portrait orientation. </dd>
+
+				<dt id="page-spread-center"> page-spread-center </dt>
+				<dd> Specifies the forced placement of a Content Document in a <a
+						href="http://www.idpf.org/epub3/latest#gloss-synthetic-spread">Synthetic Spread</a>
+				</dd>
+
+				<dt id="page-spread-left">page-spread-left</dt>
+				<dd>The <code>rendition:page-spread-left</code> property is an alias for the <code><a
+							href="http://www.idpf.org/epub/vocab/package/itemref/#page-spread-left"
+						>page-spread-left</a></code> property [[!SpineVocab]].</dd>
+
+				<dt id="page-spread-right">page-spread-right</dt>
+				<dd>The <code>rendition:page-spread-right</code> property is an alias for the <code><a
+							href="http://www.idpf.org/epub/vocab/package/itemref/#page-spread-right"
+							>page-spread-right</a></code> property [[!RenditionVocab]].</dd>
+
+				<dt id="spread-auto"> spread-auto </dt>
+				<dd> Specifies the Reading System can determine when to render a synthetic spread for the spine item. </dd>
+
+				<dt id="spread-both"> spread-both </dt>
+				<dd> Specifies the Reading System should render a synthetic spread for the spine item in both portrait
+					and landscape orientations. </dd>
+
+				<dt id="spread-landscape"> spread-landscape </dt>
+				<dd> Specifies the Reading System should render a synthetic spread for the spine item only when in
+					landscape orientation. </dd>
+
+				<dt id="spread-none"> spread-none </dt>
+				<dd> Specifies the Reading System should not render a synthetic spread for the spine item. </dd>
+
+				<dt id="spread-portrait">spread-portrait</dt>
+				<dd>The <code>spread-portrait</code> property is <a href="http://www.idpf.org/epub3/latest#deprecated"
+						>deprecated</a> in [[!EPUB3]]. Refer to its definition in [[!Publications301]] for more
+					information.</dd>
+			</dl>
+		</section>
+	</body>
+</html>

--- a/vocab/structure/magazine/magazine.html
+++ b/vocab/structure/magazine/magazine.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB 3 Magazine Navigation Vocabulary</title>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/structure/magazine/magazine.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						"name": "Bill Kasdorf",
+						"company": "Kasdorf & Associates, LLC"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				}
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<p>This document describes a magazine-specific structural vocabulary.</p>
+		</section>
+		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+		</section>
+		<section id="about" class="informative">
+			<h2>About this vocabulary</h2>
+
+			<div property="dcterms:description">
+				<p>The intention of these terms is to assist in navigation, so each identifies a semantically distinct
+					portion of a magazine page that may be repositioned in relation to the others on that page for a
+					specific rendition (e.g., to accommodate different aspect ratios or viewport dimensions, while
+					enabling proper navigation between them, whether repositioned or not).</p>
+			</div>
+		</section>
+		<section id="conformance"></section>
+		<section id="prism">
+			<h2>PRISM Controlled Vocabularies</h2>
+
+			<p>The <a
+					href="http://www.idealliance.org/specifications/prism-metadata-initiative/prism/specifications/controlled-vocabularies"
+					>PRISM Controlled Vocabularies</a> should be used to provide industry-standard magazine semantics to
+				aid in region-based navigation.</p>
+
+			<p>In particular, the following subset of terms from the <a
+					href="http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#_Toc337191589">PAM
+					Content Class Vocabulary</a> are recommended for their use in magazine navigation:</p>
+
+			<ul>
+				<li>title</li>
+				<li>deck</li>
+				<li>subtitle</li>
+				<li>byline</li>
+				<li>contributors</li>
+				<li>caption</li>
+				<li>credit</li>
+				<li>box</li>
+				<li>advertisement</li>
+				<li>pullQuote</li>
+			</ul>
+
+			<p>When using these terms for EPUB region-based navigation, the predefined prefix "<code>prism:</code>" is
+				required.</p>
+		</section>
+		<section id="vocab" class="vocabulary">
+			<h2 about="#regions" rev="dcterms:title">Additional Regions</h2>
+
+			<div id="regions" about="#regions" typeof="rdf:Bag">
+				<dl about="#regions" rev="rdfs:member">
+					<dt id="article-region" about="#article-region" typeof="rdf:Property">article-region<span
+							class="status draft"></span>
+					</dt>
+					<dd about="#article-region" property="rdfs:comment" datatype="xsd:string">
+						<p>A region containing an article in full, or a portion of a multi-page article. Note that the
+							presence of this property does not imply semantic integrity: the boundaries of an
+							article-region are arbitrary, not necessarily aligned with the semantic components of an
+							article.</p>
+					</dd>
+					<dt id="article-text" about="#article-text" typeof="rdf:Property">article-text<span
+							class="status draft"></span>
+					</dt>
+					<dd about="#article-text" property="rdfs:comment" datatype="xsd:string">
+						<p>A region that contains the text of the article.</p>
+					</dd>
+					<dt id="media" about="#media" typeof="rdf:Property">media<span class="status draft"></span>
+					</dt>
+					<dd about="#media" property="rdfs:comment" datatype="xsd:string">
+						<p>A region that contains an image or illustration or, more generally, a piece of media allowed
+							by the format. The region may contain a video, a slideshow, an HTML animation inserted in
+							the page, or similar multimedia component.</p>
+					</dd>
+				</dl>
+			</div>
+		</section>
+	</body>
+</html>

--- a/vocab/structure/structure.html
+++ b/vocab/structure/structure.html
@@ -1,0 +1,2484 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>EPUB 3 Structural Semantics Vocabulary</title>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
+		<script class="remove">
+		  // <![CDATA[
+			var respecConfig = {
+				wg: "EPUB 3 Community Group",
+				wgURI: "https://www.w3.org/community/epub3/",
+				wgPublicList: "public-epub3",
+				specStatus: "CG-DRAFT",
+				edDraftURI: "https://idpf.github.io/epub-vocabs/vocab/structure/structure.html",
+				// publishDate: "2018-03-26",
+				noRecTrack: true,
+				editors: [
+					{
+						"name": "Matt Garrish",
+						"company": "DAISY Consortium",
+						"companyURL": "http://www.daisy.org",
+						"w3cid": 51655
+					},
+					{
+						name: "Tzviya Siegman",
+						company: "John Wiley & Sons",
+						companyURL: "http://wiley.com"
+					}
+				],
+				formerEditors: [
+					{
+						name: "Markus Gylling",
+						company: "International Digital Publishing Forum (IDPF)",
+						companyURL: "http://idpf.org"
+					}
+				],
+				processVersion: 2018,
+				includePermalinks: true,
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				github: {
+					repoURL: "https://github.com/idpf/epub-vocabs",
+					branch: "master"
+				}
+			};
+          // ]]>
+      </script>
+	</head>
+	<body>
+		<section id="abstract">
+			<h2>Abstract</h2>
+
+			<p>This vocabulary, a part of EPUB® 3, defines a set of properties relating to the description of structural
+				semantics of written works.</p>
+		</section>
+		<section id="sotd">
+			<p>This document contains draft terms from the <a href="http://www.idpf.org/epub/profiles/edu/spec/">EDUPUB
+					profile</a>.</p>
+
+			<p>Any use of terms marked <span class="status draft">[draft]</span> should be considered experimental.</p>
+
+			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
+				terms are no longer recommended for use.</p>
+
+			<p>Requests for additions, modifications and clarifications can be made through the <a
+					href="https://github.com/IDPF/epub-vocabs/issues">Issue Tracker</a>. <a
+					href="https://github.com/IDPF/epub-vocabs/pulls">Pull requests</a> are also welcome.</p>
+		</section>
+		<section id="about">
+			<h2>About this vocabulary</h2>
+
+			<div property="dcterms:description">
+				<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
+					constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
+				<p class="output-htu-expl" id="htu-expl">The <i>HTML usage context</i> fields indicate contexts in HTML
+					documents where the given property is considered relevant. Authors may use the properties on HTML
+					markup elements not specifically listed, but must ensure that the semantics they express represent a
+					subset of the carrying element's semantics and do not attach an existing element's meaning to a
+					semantically neutral element.</p>
+				<p class="output-htu-expl">When processing HTML documents, Reading Systems may ignore such non-compliant
+					properties, unless their usage context is explicitly overridden or extended by the host
+					specification.</p>
+				<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
+					properties.</p>
+			</div>
+		</section>
+		<section id="partitions" about="#partitions" typeof="rdf:Bag">
+			<h2 about="#partitions" rev="dcterms:title">Document partitions</h2>
+
+			<dl about="#partitions" rev="rdfs:member">
+				<dt id="cover" about="#cover" typeof="rdf:Property">cover</dt>
+				<dd about="#cover" property="rdfs:comment" datatype="xsd:string">
+					<p>A section that introduces the work, often consisting of a marketing image, the title, author and
+						publisher, and select quotes and reviews.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="frontmatter" about="#frontmatter" typeof="rdf:Property">frontmatter</dt>
+				<dd about="#frontmatter" property="rdfs:comment" datatype="xsd:string">
+					<p>Preliminary material to the main content of a publication, such as tables of contents,
+						dedications, etc.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="bodymatter" about="#bodymatter" typeof="rdf:Property">bodymatter</dt>
+				<dd about="#bodymatter" property="rdfs:comment" datatype="xsd:string">
+					<p>The main content of a publication.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="backmatter" about="#backmatter" typeof="rdf:Property">backmatter</dt>
+				<dd about="#backmatter" property="rdfs:comment" datatype="xsd:string">
+					<p>Ancillary material occurring after the main content of a publication, such as indices,
+						appendices, etc.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="divisions" about="#divisions" typeof="rdf:Bag">
+			<h2 about="#divisions" rev="dcterms:title">Document divisions</h2>
+
+			<dl about="#divisions" rev="rdfs:member">
+				<dt id="volume" about="#volume" typeof="rdf:Property">volume</dt>
+				<dd about="#volume" property="rdfs:comment" datatype="xsd:string">
+					<p>A component of a collection.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="part" about="#part" typeof="rdf:Property">part</dt>
+				<dd about="#part" property="rdfs:comment" datatype="xsd:string">
+					<p>A major structural division in a work that contains a set of related sections dealing with a
+						particular subject, narrative arc or similar encapsulated theme.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="chapter" about="#chapter" typeof="rdf:Property">chapter</dt>
+				<dd about="#chapter" property="rdfs:comment" datatype="xsd:string">
+					<p>A major thematic section of content in a work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="subchapter" about="#subchapter" typeof="rdf:Property">subchapter<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#subchapter" property="rdfs:comment" datatype="xsd:string">
+					<p>A major sub-division of a chapter.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dt id="division" about="#division" typeof="rdf:Property">division</dt>
+				<dd about="#division" property="rdfs:comment" datatype="xsd:string">
+					<p>A major structural division that may also appear as a substructure of a part (esp. in
+						legislation).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="sections" about="#sections" typeof="rdf:Bag">
+			<h2 about="#sections" rev="dcterms:title">Document sections and components</h2>
+
+			<p about="#sections" rev="dcterms:description">Sections and components that typically occur in the
+				publication bodymatter.</p>
+			<dl about="#sections" rev="rdfs:member">
+				<dt id="abstract-1" about="#abstract-1" typeof="rdf:Property">abstract<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#abstract-1" property="rdfs:comment" datatype="xsd:string">
+					<p>A short summary of the principle ideas, concepts and conclusions of the work, or of a section or
+						excerpt within it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="foreword" about="#foreword" typeof="rdf:Property">foreword</dt>
+				<dd about="#foreword" property="rdfs:comment" datatype="xsd:string">
+					<p>An introductory section that precedes the work, typically not written by the author of the
+						work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="preface" about="#preface" typeof="rdf:Property">preface</dt>
+				<dd about="#preface" property="rdfs:comment" datatype="xsd:string">
+					<p>An introductory section that precedes the work, typically written by the author of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="prologue" about="#prologue" typeof="rdf:Property">prologue</dt>
+				<dd about="#prologue" property="rdfs:comment" datatype="xsd:string">
+					<p>An introductory section that sets the background to a work, typically part of the narrative.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="introduction" about="#introduction" typeof="rdf:Property">introduction</dt>
+				<dd about="#introduction" property="rdfs:comment" datatype="xsd:string">
+					<p>A preliminary section that typically introduces the scope or nature of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="preamble" about="#preamble" typeof="rdf:Property">preamble</dt>
+				<dd about="#preamble" property="rdfs:comment" datatype="xsd:string">
+					<p>A section in the beginning of the work, typically containing introductory and/or explanatory
+						prose regarding the scope or nature of the work's content</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="conclusion" about="#conclusion" typeof="rdf:Property">conclusion</dt>
+				<dd about="#conclusion" property="rdfs:comment" datatype="xsd:string">
+					<p>A concluding section or statement that summarizes the work or wraps up the narrative.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="epilogue" about="#epilogue" typeof="rdf:Property">epilogue</dt>
+				<dd about="#epilogue" property="rdfs:comment" datatype="xsd:string">
+					<p>A concluding section of narrative that wraps up or comments on the actions and events of the
+						work, typically from a future perspective.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="afterword" about="#afterword" typeof="rdf:Property">afterword</dt>
+				<dd about="#afterword" property="rdfs:comment" datatype="xsd:string">
+					<p>A closing statement from the author or a person of importance, typically providing insight into
+						how the content came to be written, its significance, or related events that have transpired
+						since its timeline.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="epigraph" about="#epigraph" typeof="rdf:Property">epigraph</dt>
+				<dd about="#epigraph" property="rdfs:comment" datatype="xsd:string">
+					<p>A quotation set at the start of the work or a section that establishes the theme or sets the
+						mood.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="navigation" about="#navigation" typeof="rdf:Bag">
+			<h2 about="#navigation" rev="dcterms:title">Document navigation</h2>
+
+			<dl about="#navigation" rev="rdfs:member">
+				<dt id="toc-1" about="#toc-1" typeof="rdf:Property">toc</dt>
+				<dd about="#toc-1" property="rdfs:comment" datatype="xsd:string">
+					<p>A navigational aid that provides an ordered list of links to the major sectional headings in the
+						content. A table of contents may cover an entire work, or only a smaller section of it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="toc-brief" about="#toc-brief" typeof="rdf:Property">toc-brief<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#toc-brief" property="rdfs:comment" datatype="xsd:string">
+					<p>An abridged version of the table of contents.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="landmarks" about="#landmarks" typeof="rdf:Property">landmarks</dt>
+				<dd about="#landmarks" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of references to well-known/recurring components within the publication</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="loa" about="#loa" typeof="rdf:Property">loa</dt>
+				<dd about="#loa" property="rdfs:comment" datatype="xsd:string">
+					<p>A listing of audio clips included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="loi" about="#loi" typeof="rdf:Property">loi</dt>
+				<dd about="#loi" property="rdfs:comment" datatype="xsd:string">
+					<p>A listing of illustrations included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="lot" about="#lot" typeof="rdf:Property">lot</dt>
+				<dd about="#lot" property="rdfs:comment" datatype="xsd:string">
+					<p>A listing of tables included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="lov" about="#lov" typeof="rdf:Property">lov</dt>
+				<dd about="#lov" property="rdfs:comment" datatype="xsd:string">
+					<p>A listing of video clips included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="references" about="#references" typeof="rdf:Bag">
+			<h2 about="#references" rev="dcterms:title">Document reference sections</h2>
+
+			<dl about="#references" rev="rdfs:member">
+				<dt id="appendix" about="#appendix" typeof="rdf:Property">appendix</dt>
+				<dd about="#appendix" property="rdfs:comment" datatype="xsd:string">
+					<p>A section of supplemental information located after the primary content that informs the content
+						but is not central to it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="colophon" about="#colophon" typeof="rdf:Property">colophon</dt>
+				<dd about="#colophon" property="rdfs:comment" datatype="xsd:string">
+					<p>A short section of production notes particular to the edition (e.g., describing the typeface
+						used), often located at the end of a work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+							>grouping content</a>
+					</p>
+				</dd>
+				<dt id="credits" about="#credits" typeof="rdf:Property">credits<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#credits" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#credit">credits</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+							>grouping content</a>
+					</p>
+				</dd>
+				<dt id="keywords" about="#keywords" typeof="rdf:Property">keywords<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#keywords" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#keyword">keywords</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+							>grouping content</a>
+					</p>
+				</dd>
+			</dl>
+			<div id="indexes" about="#indexes" typeof="rdf:Bag">
+				<h3 id="h_indexes" about="#indexes" rev="dcterms:title">Indexes</h3>
+				<dl about="#indexes" rev="rdfs:member">
+					<dt id="index" about="#index" typeof="rdf:Property">index</dt>
+					<dd about="#index" property="rdfs:comment" datatype="xsd:string">
+						<p>A navigational aid that provides a detailed list of links to key subjects, names and other
+							important topics covered in the work.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/sections.html#the-body-element"
+								>body</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-index">EPUB Indexes – index
+								property</a>
+						</p>
+					</dd>
+					<dt id="index-headnotes" about="#index-headnotes" typeof="rdf:Property">index-headnotes</dt>
+					<dd about="#index-headnotes" property="rdfs:comment" datatype="xsd:string">
+						<p>Narrative or other content to assist users in using the index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-headnotes" rel="role:scope" resource="#index">
+								<a href="#index">index</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/sections.html#the-header-element"
+								>header</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-headnotes">EPUB Indexes –
+								index-headnotes property</a>
+						</p>
+					</dd>
+					<dt id="index-legend" about="#index-legend" typeof="rdf:Property">index-legend</dt>
+					<dd about="#index-legend" property="rdfs:comment" datatype="xsd:string">
+						<p>List of symbols, abbreviations or special formatting used in the index, and their
+							meanings.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-legend" rel="role:scope" resource="#index-headnotes">
+								<a href="#index-headnotes">index-headnotes</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element"
+								>dl</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-legend">EPUB Indexes –
+								index-legend property</a>
+						</p>
+					</dd>
+					<dt id="index-group" about="#index-group" typeof="rdf:Property">index-group</dt>
+					<dd about="#index-group" property="rdfs:comment" datatype="xsd:string">
+						<p>Collection of consecutive main entries that share a common characteristic, for example the
+							starting letter of the main entries.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-group" rel="role:scope" resource="#index">
+								<a href="#index">index</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-group">EPUB Indexes – index-group
+								property</a>
+						</p>
+					</dd>
+					<dt id="index-entry-list" about="#index-entry-list" typeof="rdf:Property">index-entry-list</dt>
+					<dd about="#index-entry-list" property="rdfs:comment" datatype="xsd:string">
+						<p>Collection of consecutive main entries or subentries.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-entry-list" rel="role:scope" resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>, <span class="subpropref" about="#index-entry-list" rel="role:scope"
+								resource="#index-group">
+								<a href="#index-group">index-group</a>
+							</span> and <span class="subpropref" about="#index-entry-list" rel="role:scope"
+								resource="#index">
+								<a href="#index">index</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element">ul</a>; this
+							property is implied when the ul has an ancestor of index except within index-headnotes</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-entry-list">EPUB Indexes –
+								index-entry-list property</a>
+						</p>
+					</dd>
+					<dt id="index-entry" about="#index-entry" typeof="rdf:Property">index-entry</dt>
+					<dd about="#index-entry" property="rdfs:comment" datatype="xsd:string">
+						<p>One term with any attendant subentries, locators, cross references, and/or editorial
+							note.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-entry" rel="role:scope" resource="#index-entry-list">
+								<a href="#index-entry-list">index-entry-list</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>; this
+							property is implied when parent ul is of type index-entry-list (implicit or explicit)</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-entry">EPUB Indexes – index-entry
+								property</a>
+						</p>
+					</dd>
+					<dt id="index-term" about="#index-term" typeof="rdf:Property">index-term</dt>
+					<dd about="#index-term" property="rdfs:comment" datatype="xsd:string">
+						<p>Word, phrase, string, glyph or image representing the indexable content.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-term" rel="role:scope" resource="#index-xref-related">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span>, <span class="subpropref" about="#index-term" rel="role:scope"
+								resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span> and <span class="subpropref" about="#index-term" rel="role:scope"
+								resource="#index-xref-preferred">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+								content</a>; typically <a
+								href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">span</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term">EPUB Indexes – index-term
+								property</a>
+						</p>
+					</dd>
+					<dt id="index-editor-note" about="#index-editor-note" typeof="rdf:Property">index-editor-note</dt>
+					<dd about="#index-editor-note" property="rdfs:comment" datatype="xsd:string">
+						<p>Editorial note pertaining to a single entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-editor-note" rel="role:scope" resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-editor-note">EPUB Indexes –
+								index-editor-note property</a>
+						</p>
+					</dd>
+					<dt id="index-locator" about="#index-locator" typeof="rdf:Property">index-locator</dt>
+					<dd about="#index-locator" property="rdfs:comment" datatype="xsd:string">
+						<p>A reference to an occurrence of the indexed content in the publication.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-locator" rel="role:scope" resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>, <span class="subpropref" about="#index-locator" rel="role:scope"
+								resource="#index-locator-list">
+								<a href="#index-locator-list">index-locator-list</a>
+							</span> and <span class="subpropref" about="#index-locator" rel="role:scope"
+								resource="#index-locator-range">
+								<a href="#index-locator-range">index-locator-range</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>; this
+							property is implied when parent context is index-locator-list or index-locator-range</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator">EPUB Indexes –
+								index-locator property</a>
+						</p>
+					</dd>
+					<dt id="index-locator-list" about="#index-locator-list" typeof="rdf:Property"
+						>index-locator-list</dt>
+					<dd about="#index-locator-list" property="rdfs:comment" datatype="xsd:string">
+						<p>Collection of sequential locators or locator ranges.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-locator-list" rel="role:scope"
+								resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element">ul</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator-list">EPUB Indexes –
+								index-locator-list property</a>
+						</p>
+					</dd>
+					<dt id="index-locator-range" about="#index-locator-range" typeof="rdf:Property"
+						>index-locator-range</dt>
+					<dd about="#index-locator-range" property="rdfs:comment" datatype="xsd:string">
+						<p>A pair of locators that connects a term to a range of content rather than a single point.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-locator-range" rel="role:scope"
+								resource="#index-locator-list">
+								<a href="#index-locator-list">index-locator-list</a>
+							</span> and <span class="subpropref" about="#index-locator-range" rel="role:scope"
+								resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator-range">EPUB Indexes –
+								index-locator-range property</a>
+						</p>
+					</dd>
+					<dt id="index-xref-preferred" about="#index-xref-preferred" typeof="rdf:Property"
+						>index-xref-preferred</dt>
+					<dd about="#index-xref-preferred" property="rdfs:comment" datatype="xsd:string">
+						<p>Reference from one term to one or more preferred terms or term categories in an index
+							(analogous to "See xxx").</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-xref-preferred" rel="role:scope"
+								resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-xref-preferred">EPUB Indexes –
+								index-xref-preferred property</a>
+						</p>
+					</dd>
+					<dt id="index-xref-related" about="#index-xref-related" typeof="rdf:Property"
+						>index-xref-related</dt>
+					<dd about="#index-xref-related" property="rdfs:comment" datatype="xsd:string">
+						<p>Reference from one term to one or more related terms or term categories in an index
+							(analogous to "See also xxx").</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-xref-related" rel="role:scope"
+								resource="#index-entry">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-xref-related">EPUB Indexes –
+								index-xref-related property</a>
+						</p>
+					</dd>
+					<dt id="index-term-category" about="#index-term-category" typeof="rdf:Property"
+						>index-term-category</dt>
+					<dd about="#index-term-category" property="rdfs:comment" datatype="xsd:string">
+						<p>Word, phrase, string, glyph or image representing a category of terms in the index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-term-category" rel="role:scope"
+								resource="#index-xref-related">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span> and <span class="subpropref" about="#index-term-category" rel="role:scope"
+								resource="#index-xref-preferred">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term-category">EPUB Indexes –
+								index-term-category property</a>
+						</p>
+					</dd>
+					<dt id="index-term-categories" about="#index-term-categories" typeof="rdf:Property"
+						>index-term-categories</dt>
+					<dd about="#index-term-categories" property="rdfs:comment" datatype="xsd:string">
+						<p>Wrapper for a list of the term categories belonging to an index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#index-term-categories" rel="role:scope"
+								resource="#index-xref-related">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span> and <span class="subpropref" about="#index-term-categories" rel="role:scope"
+								resource="#index-xref-preferred">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term-categories">EPUB Indexes –
+								index-term-categories property</a>
+						</p>
+					</dd>
+				</dl>
+			</div>
+			<div id="glossaries" about="#glossaries" typeof="rdf:Bag">
+				<h3 id="h_glossaries" about="#glossaries" rev="dcterms:title">Glossaries</h3>
+				<dl about="#glossaries" rev="rdfs:member">
+					<dt id="glossary" about="#glossary" typeof="rdf:Property">glossary</dt>
+					<dd about="#glossary" property="rdfs:comment" datatype="xsd:string">
+						<p>A brief dictionary of new, uncommon or specialized terms used in the content.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>, <a
+								href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+								>sectioning content</a>
+						</p>
+					</dd>
+					<dt id="glossterm" about="#glossterm" typeof="rdf:Property">glossterm</dt>
+					<dd about="#glossterm" property="rdfs:comment" datatype="xsd:string">
+						<p>A glossary term.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#glossterm" rel="role:scope" resource="#glossary">
+								<a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>The glossterm property is implied on
+								<a href="https://www.w3.org/TR/html/grouping-content.html#the-dt-element">dt</a>
+							elements within a <a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element"
+								>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
+					</dd>
+					<dt id="glossdef" about="#glossdef" typeof="rdf:Property">glossdef</dt>
+					<dd about="#glossdef" property="rdfs:comment" datatype="xsd:string">
+						<p>The definition of a <a href="#glossterm">term in a glossary</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#glossdef" rel="role:scope" resource="#glossary">
+								<a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>The glossdef property is implied on <a
+								href="https://www.w3.org/TR/html/grouping-content.html#the-dd-element">dd</a> elements
+							within a <a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>
+							element marked with the <a href="#glossary">glossary</a> property.</p>
+					</dd>
+				</dl>
+			</div>
+			<div id="bibliographies" about="#bibliographies" typeof="rdf:Bag">
+				<h3 id="h_bibliographies" about="#bibliographies" rev="dcterms:title">Bibliographies</h3>
+				<dl about="#bibliographies" rev="rdfs:member">
+					<dt id="bibliography" about="#bibliography" typeof="rdf:Property">bibliography</dt>
+					<dd about="#bibliography" property="rdfs:comment" datatype="xsd:string">
+						<p>A list of external references cited in the work, which may be to print or digital
+							sources.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dt id="biblioentry" about="#biblioentry" typeof="rdf:Property">biblioentry</dt>
+					<dd about="#biblioentry" property="rdfs:comment" datatype="xsd:string">
+						<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
+							biblioentry typically provides more detailed information than its reference(s) in the
+							content (e.g., full title, author(s), publisher, publication date, etc.).</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref" about="#biblioentry" rel="role:scope" resource="#bibliography">
+								<a href="#bibliography">bibliography</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+				</dl>
+			</div>
+		</section>
+		<section id="preliminary" about="#preliminary" typeof="rdf:Bag">
+			<h2 about="#preliminary" rev="dcterms:title">Preliminary sections and components</h2>
+
+			<p about="#preliminary" rev="dcterms:description">Preliminary sections and components, typically occuring in
+				the publication frontmatter.</p>
+			<dl about="#preliminary" rev="rdfs:member">
+				<dt id="titlepage" about="#titlepage" typeof="rdf:Property">titlepage</dt>
+				<dd about="#titlepage" property="rdfs:comment" datatype="xsd:string">
+					<p>The title page of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="halftitlepage" about="#halftitlepage" typeof="rdf:Property">halftitlepage</dt>
+				<dd about="#halftitlepage" property="rdfs:comment" datatype="xsd:string">
+					<p>The half title page of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="copyright-page" about="#copyright-page" typeof="rdf:Property">copyright-page</dt>
+				<dd about="#copyright-page" property="rdfs:comment" datatype="xsd:string">
+					<p>The copyright page of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="seriespage" about="#seriespage" typeof="rdf:Property">seriespage <span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#seriespage" property="rdfs:comment" datatype="xsd:string">
+					<p>Marketing section used to list related publications.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="acknowledgments" about="#acknowledgments" typeof="rdf:Property">acknowledgments</dt>
+				<dd about="#acknowledgments" property="rdfs:comment" datatype="xsd:string">
+					<p>A section or statement that acknowledges significant contributions by persons, organizations,
+						governments and other entities to the realization of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="imprint" about="#imprint" typeof="rdf:Property">imprint</dt>
+				<dd about="#imprint" property="rdfs:comment" datatype="xsd:string">
+					<p>Information relating to the publication or distribution of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="imprimatur" about="#imprimatur" typeof="rdf:Property">imprimatur</dt>
+				<dd about="#imprimatur" property="rdfs:comment" datatype="xsd:string">
+					<p>A formal statement authorizing the publication of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="contributors" about="#contributors" typeof="rdf:Property">contributors</dt>
+				<dd about="#contributors" property="rdfs:comment" datatype="xsd:string">
+					<p>A list of contributors to the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="other-credits" about="#other-credits" typeof="rdf:Property">other-credits</dt>
+				<dd about="#other-credits" property="rdfs:comment" datatype="xsd:string">
+					<p>Acknowledgments of previously published parts of the work, illustration credits, and permission
+						to quote from copyrighted material.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="errata" about="#errata" typeof="rdf:Property">errata</dt>
+				<dd about="#errata" property="rdfs:comment" datatype="xsd:string">
+					<p>A set of corrections discovered after initial publication of the work, sometimes referred to as
+						corrigenda.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="dedication" about="#dedication" typeof="rdf:Property">dedication</dt>
+				<dd about="#dedication" property="rdfs:comment" datatype="xsd:string">
+					<p>An inscription at the front of the work, typically addressed in tribute to one or more persons
+						close to the author.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="revision-history" about="#revision-history" typeof="rdf:Property">revision-history</dt>
+				<dd about="#revision-history" property="rdfs:comment" datatype="xsd:string">
+					<p>A record of changes made to a work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="asides" about="#asides" typeof="rdf:Bag">
+			<h2 about="#asides" rev="dcterms:title">Complementary content</h2>
+
+			<dl about="#asides" rev="rdfs:member">
+				<dt id="case-study" about="#case-study" typeof="rdf:Property">case-study<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#case-study" property="rdfs:comment" datatype="xsd:string">
+					<p>A detailed analysis of a specific topic.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#case-study" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="help" about="#help" typeof="rdf:Property">help<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#help" property="rdfs:comment" datatype="xsd:string">
+					<p>Helpful information that clarifies some aspect of the content or assists in its
+						comprehension.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#help" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#help" rel="dcterms:isReplacedBy">
+							<a href="#tip">tip</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="marginalia" about="#marginalia" typeof="rdf:Property">marginalia<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#marginalia" property="rdfs:comment" datatype="xsd:string">
+					<p>Content, both textual and graphical, that is offset in the margin.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#marginalia" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#marginalia" rel="dcterms:isReplacedBy">
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="notice" about="#notice" typeof="rdf:Property">notice</dt>
+				<dd about="#notice" property="rdfs:comment" datatype="xsd:string">
+					<p>Notifies the user of consequences that might arise from an action or event. Examples include
+						warnings, cautions and dangers.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="pullquote" about="#pullquote" typeof="rdf:Property">pullquote<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#pullquote" property="rdfs:comment" datatype="xsd:string">
+					<p>A distinctively placed or highlighted quotation from the current content designed to draw
+						attention to a topic or highlight a key point.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#pullquote" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+					</p>
+				</dd>
+				<dt id="sidebar" about="#sidebar" typeof="rdf:Property">sidebar<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#sidebar" property="rdfs:comment" datatype="xsd:string">
+					<p>Secondary or supplementary content, typically formatted as an inset or box.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#sidebar" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#sidebar" rel="dcterms:isReplacedBy">
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="tip" about="#tip" typeof="rdf:Property">tip</dt>
+				<dd about="#tip" property="rdfs:comment" datatype="xsd:string">
+					<p>Helpful information that clarifies some aspect of the content or assists in its
+						comprehension.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#tip" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dt id="warning" about="#warning" typeof="rdf:Property">warning<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#warning" property="rdfs:comment" datatype="xsd:string">
+					<p>A warning.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#warning" rel="dcterms:isReplacedBy">
+							<a href="#notice">notice</a>
+						</span>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="titles" about="#titles" typeof="rdf:Bag">
+			<h2 about="#titles" rev="dcterms:title">Titles and headings</h2>
+
+			<dl about="#titles" rev="rdfs:member">
+				<dt id="halftitle" about="#halftitle" typeof="rdf:Property">halftitle</dt>
+				<dd about="#halftitle" property="rdfs:comment" datatype="xsd:string">
+					<p>The title appearing on the first page of a work or immediately before the text.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#halftitle" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>. This property should only appear once within the document scope.</p>
+				</dd>
+				<dt id="fulltitle" about="#fulltitle" typeof="rdf:Property">fulltitle</dt>
+				<dd about="#fulltitle" property="rdfs:comment" datatype="xsd:string">
+					<p>The full title of the work, either simple, in which case it is identical to <a href="#title"
+							>title</a>, or compound, in which case it consists of a <a href="#title">title</a> and a <a
+							href="#subtitle">subtitle</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#fulltitle" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Same as:</span>
+						<span class="subpropref" about="#fulltitle" rel="owl:sameAs"
+							resource="http://purl.org/dc/terms/title">
+							<a href="http://purl.org/dc/terms/title">http://purl.org/dc/terms/title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>. This property should only appear once within the document scope.</p>
+				</dd>
+				<dt id="covertitle" about="#covertitle" typeof="rdf:Property">covertitle</dt>
+				<dd about="#covertitle" property="rdfs:comment" datatype="xsd:string">
+					<p>The title of the work as displayed on the work's cover.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#covertitle" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>. This property should only appear once within the document scope.</p>
+				</dd>
+				<dt id="title" about="#title" typeof="rdf:Property">title</dt>
+				<dd about="#title" property="rdfs:comment" datatype="xsd:string">
+					<p>The primary name of a document component, such as a list, table or figure.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>, <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+							>phrasing content</a> descendants of <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>.</p>
+				</dd>
+				<dt id="subtitle" about="#subtitle" typeof="rdf:Property">subtitle</dt>
+				<dd about="#subtitle" property="rdfs:comment" datatype="xsd:string">
+					<p>An explanatory or alternate title for the work, or a section or component within it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#subtitle" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>, <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+							>phrasing content</a> descendants of <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-p-element"
+							>paragraphs</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"
+							>divs</a>
+					</p>
+				</dd>
+				<dt id="label" about="#label" typeof="rdf:Property">label<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#label" property="rdfs:comment" datatype="xsd:string">
+					<p>The text label that precedes an <a href="#ordinal">ordinal</a> in a component title (e.g.,
+						'Chapter', 'Part', 'Figure', 'Table').</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#label" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">Phrasing
+							content</a> descendants of <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
+							>li</a> and <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-figcaption-element"
+							>figcaption</a>
+					</p>
+				</dd>
+				<dt id="ordinal" about="#ordinal" typeof="rdf:Property">ordinal<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#ordinal" property="rdfs:comment" datatype="xsd:string">
+					<p>An ordinal specifier for a component in a sequence of components (e.g., '1', 'IV', 'B-1').</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#ordinal" rel="rdfs:subPropertyOf" resource="#title">
+							<a href="#title">title</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">Phrasing
+							content</a> descendants of <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+							content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
+							>li</a> and <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-figcaption-element"
+							>figcaption</a>
+					</p>
+				</dd>
+				<dt id="bridgehead" about="#bridgehead" typeof="rdf:Property">bridgehead</dt>
+				<dd about="#bridgehead" property="rdfs:comment" datatype="xsd:string">
+					<p>A structurally insignificant heading that does not contribute to the hierarchical structure of
+						the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>,
+						typically <a href="https://www.w3.org/TR/html/grouping-content.html#the-p-element">p</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-div-element">div</a> or <a
+							href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">span</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="educational" about="#educational" typeof="rdf:Bag">
+			<h2 about="#educational" rev="dcterms:title">Educational content</h2>
+
+			<div id="learning-obj" about="#learning-obj" typeof="rdf:Bag">
+				<h3 id="h_learning-obj" about="#learning-obj" rev="dcterms:title">Learning objectives</h3>
+				<dl about="#learning-obj" rev="rdfs:member">
+					<dt id="learning-objective" about="#learning-objective" typeof="rdf:Property"
+						>learning-objective</dt>
+					<dd about="#learning-objective" property="rdfs:comment" datatype="xsd:string">
+						<p>An explicit designation or description of a learning objective or a reference to an explicit
+							learning objective.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>, <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+								>phrasing content</a>
+						</p>
+					</dd>
+					<dt id="learning-objectives" about="#learning-objectives" typeof="rdf:Property"
+							>learning-objectives<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-objectives" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#learning-objective">learning-objectives</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+					<dt id="learning-outcome" about="#learning-outcome" typeof="rdf:Property">learning-outcome<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-outcome" property="rdfs:comment" datatype="xsd:string">
+						<p>The understanding or ability a student is expected to achieve as a result of a lesson or
+							activity.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dt id="learning-outcomes" about="#learning-outcomes" typeof="rdf:Property">learning-outcomes<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-outcomes" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#learning-outcome">learing-outcomes</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+					<dt id="learning-resource" about="#learning-resource" typeof="rdf:Property">learning-resource</dt>
+					<dd about="#learning-resource" property="rdfs:comment" datatype="xsd:string">
+						<p>A resource provided to enhance learning, or a reference to such a resource.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>
+						</p>
+					</dd>
+					<dt id="learning-resources" about="#learning-resources" typeof="rdf:Property"
+							>learning-resources<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-resources" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#learning-resource">learning-resources</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+					<dt id="learning-standard" about="#learning-standard" typeof="rdf:Property">learning-standard<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-standard" property="rdfs:comment" datatype="xsd:string">
+						<p>A formal set of expectations or requirements typically issued by a government or a standards
+							body.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a
+								href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+								content</a>
+						</p>
+					</dd>
+					<dt id="learning-standards" about="#learning-standards" typeof="rdf:Property"
+							>learning-standards<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#learning-standards" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#learning-standard">learning-standards</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+				</dl>
+			</div>
+			<div id="testing" about="#testing" typeof="rdf:Bag">
+				<h3 id="h_testing" about="#testing" rev="dcterms:title">Testing</h3>
+				<dl about="#testing" rev="rdfs:member">
+					<dt id="answer" about="#answer" typeof="rdf:Property">answer<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#answer" property="rdfs:comment" datatype="xsd:string">
+						<p>The component of a self-assessment problem that provides the answer to the question.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="answers" about="#answers" typeof="rdf:Property">answers<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#answers" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#answer">answers</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+					<dt id="assessment" about="#assessment" typeof="rdf:Property">assessment</dt>
+					<dd about="#assessment" property="rdfs:comment" datatype="xsd:string">
+						<p>A test, quiz, or other activity that helps measure a student's understanding of what is being
+							taught.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dt id="assessments" about="#assessments" typeof="rdf:Property">assessments<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#assessments" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#assessment">assessments</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dt id="feedback" about="#feedback" typeof="rdf:Property">feedback<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#feedback" property="rdfs:comment" datatype="xsd:string">
+						<p>Instruction to the reader based on the result of an assessment.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>, <a
+								href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+								content</a>
+						</p>
+					</dd>
+					<dt id="fill-in-the-blank-problem" about="#fill-in-the-blank-problem" typeof="rdf:Property"
+							>fill-in-the-blank-problem<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#fill-in-the-blank-problem" property="rdfs:comment" datatype="xsd:string">
+						<p>A problem that requires the reader to input a text answer to complete a sentence, statement
+							or similar.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="general-problem" about="#general-problem" typeof="rdf:Property">general-problem<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#general-problem" property="rdfs:comment" datatype="xsd:string">
+						<p>A problem with a free-form solution.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="qna" about="#qna" typeof="rdf:Property">qna</dt>
+					<dd about="#qna" property="rdfs:comment" datatype="xsd:string">
+						<p>A section of content structured as a series of questions and answers, such as an interview or
+							list of frequently asked questions.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>lists or <a
+								href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+								>sectioning content</a>
+						</p>
+					</dd>
+					<dt id="match-problem" about="#match-problem" typeof="rdf:Property">match-problem<span
+							class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#match-problem" property="rdfs:comment" datatype="xsd:string">
+						<p>A problem that requires the reader to match the contents of one list with the corresponding
+							items in another list.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="multiple-choice-problem" about="#multiple-choice-problem" typeof="rdf:Property"
+							>multiple-choice-problem<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#multiple-choice-problem" property="rdfs:comment" datatype="xsd:string">
+						<p>A problem with a set of potential answers to choose from ‒ some, all or none of which may be
+							correct.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="practice" about="#practice" typeof="rdf:Property">practice<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#practice" property="rdfs:comment" datatype="xsd:string">
+						<p>A review exercise or sample.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">See also:</span>
+							<span class="subpropref" about="#practice" rel="rdfs:seeAlso" resource="#practices">
+								<a href="#practices">practices</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="question" about="#question" typeof="rdf:Property">question<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#question" property="rdfs:comment" datatype="xsd:string">
+						<p>The component of a self-assessment problem that identifies the question to be solved.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+					<dt id="practices" about="#practices" typeof="rdf:Property">practices<span class="status draft">
+							[draft]</span>
+					</dt>
+					<dd about="#practices" property="rdfs:comment" datatype="xsd:string">
+						<p>A collection of <a href="#practice">practices</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dt id="true-false-problem" about="#true-false-problem" typeof="rdf:Property"
+							>true-false-problem<span class="status draft"> [draft]</span>
+					</dt>
+					<dd about="#true-false-problem" property="rdfs:comment" datatype="xsd:string">
+						<p>A problem with either a true or false answer.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+								href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+								content</a>
+						</p>
+					</dd>
+				</dl>
+			</div>
+		</section>
+		<section id="comics" about="#comics" typeof="rdf:Bag">
+			<h2 about="#comics" rev="dcterms:title">Comics</h2>
+
+			<dl about="#comics" rev="rdfs:member">
+				<dt id="panel" about="#panel" typeof="rdf:Property">panel</dt>
+				<dd about="#panel" property="rdfs:comment" datatype="xsd:string">
+					<p>An individual frame, or drawing.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+					</p>
+				</dd>
+				<dt id="panel-group" about="#panel-group" typeof="rdf:Property">panel-group</dt>
+				<dd about="#panel-group" property="rdfs:comment" datatype="xsd:string">
+					<p>A group of <a href="#panel">panels</a> (e.g., a strip).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+					</p>
+				</dd>
+				<dt id="balloon" about="#balloon" typeof="rdf:Property">balloon</dt>
+				<dd about="#balloon" property="rdfs:comment" datatype="xsd:string">
+					<p>An area in a comic <a href="#panel">panel</a> that contains the words, spoken or thought, of a
+						character.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+					</p>
+				</dd>
+				<dt id="text-area" about="#text-area" typeof="rdf:Property">text-area</dt>
+				<dd about="#text-area" property="rdfs:comment" datatype="xsd:string">
+					<p>An area of text in a comic <a href="#panel">panel</a>. Used to represent titles, narrative text,
+						character dialogue (inside a <a href="#balloon">balloon</a> or not) and similar.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+					</p>
+				</dd>
+				<dt id="sound-area" about="#sound-area" typeof="rdf:Property">sound-area</dt>
+				<dd about="#sound-area" property="rdfs:comment" datatype="xsd:string">
+					<p>An area of text in a comic <a href="#panel">panel</a> that represents a sound.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="notes" about="#notes" typeof="rdf:Bag">
+			<h2 about="#notes" rev="dcterms:title">Notes and annotations</h2>
+
+			<dl about="#notes" rev="rdfs:member">
+				<dt id="annotation" about="#annotation" typeof="rdf:Property">annotation<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#annotation" property="rdfs:comment" datatype="xsd:string">
+					<p>Explanatory information about passages in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#annotation" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#annotation" rel="dcterms:isReplacedBy">
+							<a href="http://www.idpf.org/epub/oa">Open Annotation in EPUB</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="note" about="#note" typeof="rdf:Property">note<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#note" property="rdfs:comment" datatype="xsd:string">
+					<p>A note. This property does not carry spatial positioning semantics, as do the <a href="#footnote"
+							>footnote</a> and <a href="#endnote">endnote</a> properties. It can be used to identify
+						footnotes, endnotes, marginal notes, inline notes, and similar when legacy naming conventions
+						are not desired.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>On the <a
+							href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+						identifying a single note, or on descendants of sectioning content when identifying individual
+						notes in a group (refer to <a href="#footnotes">footnotes</a> and <a href="#endnotes"
+							>endnotes</a>).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#note" rel="dcterms:isReplacedBy">
+							<a href="#footnote">footnote</a>, <a href="#endnote">endnote</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="footnote" about="#footnote" typeof="rdf:Property">footnote</dt>
+				<dd about="#footnote" property="rdfs:comment" datatype="xsd:string">
+					<p>Ancillary information, such as a citation or commentary, that provides additional context to a
+						referenced passage of text.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#footnote" rel="rdfs:seeAlso" resource="#footnotes">
+							<a href="#footnotes">footnotes</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>On the <a
+							href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+						identifying a single footnote, or on descendants of sectioning content when identifying
+						individual footnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+							href="#endnotes">endnotes</a>).</p>
+				</dd>
+				<dt id="endnote" about="#endnote" typeof="rdf:Property">endnote</dt>
+				<dd about="#endnote" property="rdfs:comment" datatype="xsd:string">
+					<p>One of a collection of notes that occur at the end of a work, or a section within it, that
+						provides additional context to a referenced passage of text.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#endnote" rel="rdfs:seeAlso" resource="#endnotes">
+							<a href="#endnotes">endnotes</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>On the <a
+							href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+						identifying a single endnote, or on descendants of sectioning content when identifying
+						individual endnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+							href="#endnotes">endnotes</a>).</p>
+				</dd>
+				<dt id="rearnote" about="#rearnote" typeof="rdf:Property">rearnote<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#rearnote" property="rdfs:comment" datatype="xsd:string">
+					<p>A note appearing in the rear (backmatter) of the work, or at the end of a section.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#rearnote" rel="rdfs:seeAlso" resource="#rearnotes">
+							<a href="#rearnotes">rearnotes</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>On the <a
+							href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+						identifying a single rearnote, or on descendants of sectioning content when identifying
+						individual rearnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+							href="#rearnotes">rearnotes</a>).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#rearnote" rel="dcterms:isReplacedBy">
+							<a href="#endnote">endnote</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="footnotes" about="#footnotes" typeof="rdf:Property">footnotes</dt>
+				<dd about="#footnotes" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#footnote">footnotes</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#footnotes" rel="rdfs:seeAlso" resource="#footnote">
+							<a href="#footnote">footnote</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="endnotes" about="#endnotes" typeof="rdf:Property">endnotes</dt>
+				<dd about="#endnotes" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of notes at the end of a work or a section within it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#endnotes" rel="rdfs:seeAlso" resource="#endnote">
+							<a href="#endnote">endnote</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dt id="rearnotes" about="#rearnotes" typeof="rdf:Property">rearnotes<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#rearnotes" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of notes appearing at the rear (backmatter) of the work, or at the end of a
+						section.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#rearnotes" rel="rdfs:seeAlso" resource="#rearnote">
+							<a href="#rearnote">rearnote</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#rearnotes" rel="dcterms:isReplacedBy">
+							<a href="#endnotes">endnotes</a>
+						</span>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="links" about="#links" typeof="rdf:Bag">
+			<h2 about="#links" rev="dcterms:title">References</h2>
+
+			<dl about="#links" rev="rdfs:member">
+				<dt id="annoref" about="#annoref" typeof="rdf:Property">annoref<span class="status deprecated"
+						property="owl:deprecated" content="true"> [deprecated]</span>
+				</dt>
+				<dd about="#annoref" property="rdfs:comment" datatype="xsd:string">
+					<p>A reference to an annotation.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#annoref" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#link">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#annoref" rel="rdfs:seeAlso" resource="#annotation">
+							<a href="#annotation">annotation</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref" about="#annoref" rel="dcterms:isReplacedBy">
+							<a href="http://www.idpf.org/epub/oa">Open Annotation in EPUB</a>
+						</span>
+					</p>
+				</dd>
+				<dt id="biblioref" about="#biblioref" typeof="rdf:Property">biblioref<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#biblioref" property="rdfs:comment" datatype="xsd:string">
+					<p>A reference to a <a href="#biblioentry">bibliography entry</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#biblioref" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#link">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dt id="glossref" about="#glossref" typeof="rdf:Property">glossref<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#glossref" property="rdfs:comment" datatype="xsd:string">
+					<p>A reference to a <a href="#glossdef">glossary definition</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#glossref" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#link">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dt id="noteref" about="#noteref" typeof="rdf:Property">noteref</dt>
+				<dd about="#noteref" property="rdfs:comment" datatype="xsd:string">
+					<p>A reference to a note, typically appearing as a superscripted number or symbol in the main body
+						of text.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#noteref" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#link">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#noteref" rel="rdfs:seeAlso" resource="#note">
+							<a href="#note">note</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dt id="backlink" about="#backlink" typeof="rdf:Property">backlink<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#backlink" property="rdfs:comment" datatype="xsd:string">
+					<p>A link that allows the user to return to a related location in the content (e.g., from a <a
+							href="#footnote">footnote</a> to its reference or from a <a href="#glossdef">glossary
+							definition</a> to where a <a href="#glossterm">term</a> is used).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref" about="#backlink" rel="rdfs:subPropertyOf"
+							resource="http://www.w3.org/1999/xhtml/vocab/#link">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="document-text" about="#document-text" typeof="rdf:Bag">
+			<h2 about="#document-text" rev="dcterms:title">Document text</h2>
+
+			<p about="#document-text" rev="dcterms:description">Terms for describing components at the phrasing
+				level.</p>
+			<dl about="#document-text" rev="rdfs:member">
+				<dt id="credit" about="#credit" typeof="rdf:Property">credit<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#credit" property="rdfs:comment" datatype="xsd:string">
+					<p>An acknowledgment of the source of integrated content from third-party sources, such as photos.
+						Typically identifies the creator, copyright and any restrictions on reuse.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dt id="keyword" about="#keyword" typeof="rdf:Property">keyword</dt>
+				<dd about="#keyword" property="rdfs:comment" datatype="xsd:string">
+					<p>A key word or phrase.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dt id="topic-sentence" about="#topic-sentence" typeof="rdf:Property">topic-sentence</dt>
+				<dd about="#topic-sentence" property="rdfs:comment" datatype="xsd:string">
+					<p>A phrase or sentence serving as an introductory summary of the containing paragraph.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+				<dt id="concluding-sentence" about="#concluding-sentence" typeof="rdf:Property">concluding-sentence</dt>
+				<dd about="#concluding-sentence" property="rdfs:comment" datatype="xsd:string">
+					<p>A phrase or sentence serving as a concluding summary of the containing paragraph.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="pagination" about="#pagination" typeof="rdf:Bag">
+			<h2 about="#pagination" rev="dcterms:title">Pagination</h2>
+
+			<dl about="#pagination" rev="rdfs:member">
+				<dt id="pagebreak" about="#pagebreak" typeof="rdf:Property">pagebreak</dt>
+				<dd about="#pagebreak" property="rdfs:comment" datatype="xsd:string">
+					<p>A separator denoting the position before which a break occurs between two contiguous pages in a
+						statically paginated version of the content.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing</a> and
+							<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow</a>
+						content, where the value of the carrying elements title attribute takes precedence over element
+						content for the purposes of representing the pagebreak value</p>
+				</dd>
+				<dt id="page-list" about="#page-list" typeof="rdf:Property">page-list</dt>
+				<dd about="#page-list" property="rdfs:comment" datatype="xsd:string">
+					<p>A navigational aid that provides a list of links to the <a href="#pagebreak">pagebreaks</a> in
+						the content.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="tables" about="#tables" typeof="rdf:Bag">
+			<h2 about="#tables" rev="dcterms:title">Tables</h2>
+
+			<dl about="#tables" rev="rdfs:member">
+				<dt id="table" about="#table" typeof="rdf:Property">table</dt>
+				<dd about="#table" property="rdfs:comment" datatype="xsd:string">
+					<p>A structure containing data or content laid out in tabular form.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable table structure.</p>
+				</dd>
+				<dt id="table-row" about="#table-row" typeof="rdf:Property">table-row</dt>
+				<dd about="#table-row" property="rdfs:comment" datatype="xsd:string">
+					<p>A row of data or content in a tabular structure.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable table row.</p>
+				</dd>
+				<dt id="table-cell" about="#table-cell" typeof="rdf:Property">table-cell</dt>
+				<dd about="#table-cell" property="rdfs:comment" datatype="xsd:string">
+					<p>A single cell of tabular data or content.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable table cell.</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="lists" about="#lists" typeof="rdf:Bag">
+			<h2 about="#lists" rev="dcterms:title">Lists</h2>
+
+			<dl about="#lists" rev="rdfs:member">
+				<dt id="list" about="#list" typeof="rdf:Property">list</dt>
+				<dd about="#list" property="rdfs:comment" datatype="xsd:string">
+					<p>A structure that contains an enumeration of related content items.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable list structure.</p>
+				</dd>
+				<dt id="list-item" about="#list-item" typeof="rdf:Property">list-item</dt>
+				<dd about="#list-item" property="rdfs:comment" datatype="xsd:string">
+					<p>A single item in an enumeration.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable list item.</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="figures" about="#figures" typeof="rdf:Bag">
+			<h2 about="#figures" rev="dcterms:title">Figures</h2>
+
+			<dl about="#figures" rev="rdfs:member">
+				<dt id="figure" about="#figure" typeof="rdf:Property">figure</dt>
+				<dd about="#figure" property="rdfs:comment" datatype="xsd:string">
+					<p>An illustration, diagram, photo, code listing or similar, referenced from the text of a work, and
+						typically annotated with a title, caption and/or credits.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>Deprecated</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+							href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+						escapable or skippable figure.</p>
+				</dd>
+			</dl>
+		</section>
+	</body>
+</html>

--- a/vocab/structure/structure.html
+++ b/vocab/structure/structure.html
@@ -3,10 +3,20 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Structural Semantics Vocabulary</title>
+		<script>
+			function fixIDs() {
+				var abstract_section = document.getElementById('abstract');
+				var abstract_property = document.getElementById('abstract-1');
+				abstract_section.id = 'abstract-1';
+				abstract_property.id = 'abstract';
+				// currently no way to fix toc reference
+			}
+		</script>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove" defer="defer"></script>
 		<script class="remove">
 		  // <![CDATA[
 			var respecConfig = {
+				postProcess: [fixIDs],
 				wg: "EPUB 3 Community Group",
 				wgURI: "https://www.w3.org/community/epub3/",
 				wgPublicList: "public-epub3",
@@ -49,12 +59,13 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<h2>Abstract</h2>
-
 			<p>This vocabulary, a part of EPUB® 3, defines a set of properties relating to the description of structural
 				semantics of written works.</p>
 		</section>
 		<section id="sotd">
+			<p>This document is subject to change at any time. The terms defined herein will never be removed, but may
+				be deprecated.</p>
+
 			<p>This document contains draft terms from the <a href="http://www.idpf.org/epub/profiles/edu/spec/">EDUPUB
 					profile</a>.</p>
 
@@ -62,12 +73,8 @@
 
 			<p>Deprecated term are identified by the label <span class="status deprecated">[deprecated]</span>. These
 				terms are no longer recommended for use.</p>
-
-			<p>Requests for additions, modifications and clarifications can be made through the <a
-					href="https://github.com/IDPF/epub-vocabs/issues">Issue Tracker</a>. <a
-					href="https://github.com/IDPF/epub-vocabs/pulls">Pull requests</a> are also welcome.</p>
 		</section>
-		<section id="about">
+		<section id="about" class="inoformative">
 			<h2>About this vocabulary</h2>
 
 			<div property="dcterms:description">
@@ -85,6 +92,7 @@
 					properties.</p>
 			</div>
 		</section>
+		<section id="conformance"></section>
 		<section id="partitions" about="#partitions" typeof="rdf:Bag">
 			<h2 about="#partitions" rev="dcterms:title">Document partitions</h2>
 


### PR DESCRIPTION
This PR wraps all the vocabularies in a respec wrapper.

Instead of updating the index.html files, each vocabulary instead gets a new HTML file with the same name as the directory it is in. We'll use these to prepare drafts and then can publish the static versions as the existing index.html files so that nothing changes.